### PR TITLE
Add BlueZ advertising registration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     container: fedora:40
     steps:
       - name: Install dependencies
-        run: dnf -y install cmake gcc make rpm-build rpmdevtools systemd-devel systemd-rpm-macros
+        run: dnf -y install cmake gcc make rpm-build rpmdevtools systemd-devel systemd-rpm-macros bluez-libs-devel
 
       - name: Checkout
         uses: actions/checkout@v4
@@ -56,7 +56,7 @@ jobs:
             -v "${GITHUB_WORKSPACE}:/workspace" \
             -w /workspace \
             fedora:40 \
-            bash -c "dnf -y install cmake gcc make rpm-build rpmdevtools systemd-devel systemd-rpm-macros && scripts/build_rpm.sh"
+            bash -c "dnf -y install cmake gcc make rpm-build rpmdevtools systemd-devel systemd-rpm-macros bluez-libs-devel && scripts/build_rpm.sh"
 
       - name: Upload RPMs (aarch64)
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     container: fedora:40
     steps:
       - name: Install dependencies
-        run: dnf -y install cmake gcc make rpm-build rpmdevtools systemd-rpm-macros
+        run: dnf -y install cmake gcc make rpm-build rpmdevtools systemd-rpm-macros bluez-libs-devel
 
       - name: Checkout
         uses: actions/checkout@v4

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ ansible/
 # Build artifacts
 .build/
 build/
+
+# Research sources (local-only)
+.research_sources/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,13 +20,10 @@ target_include_directories(k10-barrel-emulatord PRIVATE include)
 target_compile_options(k10-barrel-emulatord PRIVATE -Wall -Wextra -Wpedantic)
 
 find_package(PkgConfig REQUIRED)
-pkg_check_modules(SYSTEMD REQUIRED libsystemd)
-pkg_check_modules(BLUEZ REQUIRED bluez)
+pkg_check_modules(SYSTEMD REQUIRED IMPORTED_TARGET libsystemd)
+pkg_check_modules(BLUEZ REQUIRED IMPORTED_TARGET bluez)
 target_compile_definitions(k10-barrel-emulatord PRIVATE K10_USE_SYSTEMD)
-target_include_directories(k10-barrel-emulatord PRIVATE ${SYSTEMD_INCLUDE_DIRS})
-target_link_libraries(k10-barrel-emulatord PRIVATE ${SYSTEMD_LIBRARIES} ${BLUEZ_LIBRARIES})
-target_include_directories(k10-barrel-emulatord PRIVATE ${BLUEZ_INCLUDE_DIRS})
-target_compile_definitions(k10-barrel-emulatord PRIVATE ${BLUEZ_CFLAGS_OTHER})
+target_link_libraries(k10-barrel-emulatord PRIVATE PkgConfig::SYSTEMD PkgConfig::BLUEZ)
 
 add_executable(k10-barrel-emulatorctl
     src/cli/main.c
@@ -35,8 +32,7 @@ add_executable(k10-barrel-emulatorctl
 target_include_directories(k10-barrel-emulatorctl PRIVATE include)
 
 target_compile_options(k10-barrel-emulatorctl PRIVATE -Wall -Wextra -Wpedantic)
-target_include_directories(k10-barrel-emulatorctl PRIVATE ${SYSTEMD_INCLUDE_DIRS})
-target_link_libraries(k10-barrel-emulatorctl PRIVATE ${SYSTEMD_LIBRARIES})
+target_link_libraries(k10-barrel-emulatorctl PRIVATE PkgConfig::SYSTEMD)
 
 install(TARGETS k10-barrel-emulatord k10-barrel-emulatorctl
     RUNTIME DESTINATION bin

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,9 +21,12 @@ target_compile_options(k10-barrel-emulatord PRIVATE -Wall -Wextra -Wpedantic)
 
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(SYSTEMD REQUIRED libsystemd)
+pkg_check_modules(BLUEZ REQUIRED bluez)
 target_compile_definitions(k10-barrel-emulatord PRIVATE K10_USE_SYSTEMD)
 target_include_directories(k10-barrel-emulatord PRIVATE ${SYSTEMD_INCLUDE_DIRS})
-target_link_libraries(k10-barrel-emulatord PRIVATE ${SYSTEMD_LIBRARIES})
+target_link_libraries(k10-barrel-emulatord PRIVATE ${SYSTEMD_LIBRARIES} ${BLUEZ_LIBRARIES})
+target_include_directories(k10-barrel-emulatord PRIVATE ${BLUEZ_INCLUDE_DIRS})
+target_compile_definitions(k10-barrel-emulatord PRIVATE ${BLUEZ_CFLAGS_OTHER})
 
 add_executable(k10-barrel-emulatorctl
     src/cli/main.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ set(CMAKE_C_STANDARD_REQUIRED ON)
 add_executable(k10-barrel-emulatord
     src/daemon/main.c
     src/daemon/daemon.c
+    src/ble/advertising.c
     src/dbus/dbus.c
     src/config/config.c
     src/log/log.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,7 @@ add_executable(k10-barrel-emulatord
     src/daemon/main.c
     src/daemon/daemon.c
     src/ble/advertising.c
+    src/ble/gatt.c
     src/dbus/dbus.c
     src/config/config.c
     src/log/log.c

--- a/config/k10-barrel-emulator.toml
+++ b/config/k10-barrel-emulator.toml
@@ -2,11 +2,15 @@ adapter = "hci0"
 local_name = "WoS1MB"
 company_id = 0x0969
 manufacturer_mac_label = ""
+sweeper_mfg_suffix = "2064"
+barrel_mfg_suffix = "16230200"
 service_uuids = [
   "CBA20D00-224D-11E6-9FB8-0002A5D5C51B",
   "B000"
 ]
 fd3d_service_data_hex = "00"
+sweeper_fd3d_service_data_hex = "7d00"
+barrel_fd3d_service_data_hex = ""
 include_tx_power = true
 fw_major = 1
 fw_minor = 0

--- a/config/k10-barrel-emulator.toml
+++ b/config/k10-barrel-emulator.toml
@@ -13,5 +13,6 @@ fd3d_service_data_hex = "00"
 sweeper_fd3d_service_data_hex = "7d00"
 barrel_fd3d_service_data_hex = ""
 include_tx_power = true
+use_random_address = true
 fw_major = 1
 fw_minor = 0

--- a/config/k10-barrel-emulator.toml
+++ b/config/k10-barrel-emulator.toml
@@ -1,5 +1,6 @@
 adapter = "hci0"
 local_name = "WoS1MB"
+advertising_backend = "bluez"
 company_id = 0x0969
 manufacturer_mac_label = ""
 sweeper_mfg_suffix = "2064"

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -161,8 +161,12 @@ Config keys (initial set):
 - `local_name` (string)
 - `company_id` (integer, hex allowed)
 - `manufacturer_mac_label` (string, hex bytes) or empty for auto
+- `sweeper_mfg_suffix` (string, hex bytes, appended after MAC; SEQ inserted automatically)
+- `barrel_mfg_suffix` (string, hex bytes, appended after MAC; SEQ inserted automatically)
 - `service_uuids` (array of strings)
 - `fd3d_service_data_hex` (string hex)
+- `sweeper_fd3d_service_data_hex` (string hex; overrides `fd3d_service_data_hex` in sweeper mode when set)
+- `barrel_fd3d_service_data_hex` (string hex; overrides `fd3d_service_data_hex` in barrel mode when set)
 - `include_tx_power` (bool)
 - `fw_major` / `fw_minor` (int)
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -25,6 +25,7 @@ Entry points:
 - `src/daemon/daemon.c` -> `k10_daemon_run()`
 - `src/config/config.c` -> `k10_config_load()` / `k10_config_save()`
 - `src/dbus/dbus.c` -> `k10_dbus_run()` / `k10_method_start()` / `k10_method_set_config()`
+- `src/ble/advertising.c` -> `k10_adv_start()` / `k10_adv_stop()`
 - `src/log/log.c` -> `k10_log_info()` / `k10_log_error()`
 
 ### Directory layout
@@ -139,7 +140,7 @@ Methods:
 - `Start() -> b`
 - `Stop() -> b`
 - `Reload() -> b` (re-read config)
-- `GetStatus() -> a{sv}` (includes mode/adapter/running)
+- `GetStatus() -> a{sv}` (includes mode/adapter/running/advertising)
 
 Signals:
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -159,6 +159,7 @@ Config keys (initial set):
 
 - `adapter` (string, e.g. `"hci0"`)
 - `local_name` (string)
+- `advertising_backend` (`"bluez"` or `"mgmt"`; `mgmt` allows custom ADV/SCAN payload split)
 - `company_id` (integer, hex allowed)
 - `manufacturer_mac_label` (string, hex bytes) or empty for auto
 - `sweeper_mfg_suffix` (string, hex bytes, appended after MAC; SEQ inserted automatically)

--- a/include/k10_barrel/advertising.h
+++ b/include/k10_barrel/advertising.h
@@ -1,0 +1,20 @@
+#ifndef K10_BARREL_ADVERTISING_H
+#define K10_BARREL_ADVERTISING_H
+
+#include <stdbool.h>
+
+#include <systemd/sd-bus.h>
+
+#include "k10_barrel/config.h"
+
+struct k10_adv_state {
+    bool registered;
+    char object_path[128];
+    sd_bus_slot *slot;
+    struct k10_config config;
+};
+
+int k10_adv_start(sd_bus *bus, struct k10_adv_state *state, const struct k10_config *config);
+int k10_adv_stop(sd_bus *bus, struct k10_adv_state *state);
+
+#endif

--- a/include/k10_barrel/advertising.h
+++ b/include/k10_barrel/advertising.h
@@ -9,8 +9,10 @@
 
 struct k10_adv_state {
     bool registered;
+    bool pending;
     char object_path[128];
     sd_bus_slot *slot;
+    sd_bus_slot *pending_slot;
     struct k10_config config;
 };
 

--- a/include/k10_barrel/advertising.h
+++ b/include/k10_barrel/advertising.h
@@ -10,6 +10,11 @@
 struct k10_adv_state {
     bool registered;
     bool pending;
+    bool include_service_uuids;
+    bool include_service_data;
+    bool include_manufacturer_data;
+    bool include_local_name;
+    bool include_tx_power;
     char object_path[128];
     sd_bus_slot *slot;
     sd_bus_slot *pending_slot;

--- a/include/k10_barrel/advertising.h
+++ b/include/k10_barrel/advertising.h
@@ -2,6 +2,7 @@
 #define K10_BARREL_ADVERTISING_H
 
 #include <stdbool.h>
+#include <stdint.h>
 
 #include <systemd/sd-bus.h>
 
@@ -15,6 +16,7 @@ struct k10_adv_state {
     bool include_manufacturer_data;
     bool include_local_name;
     bool include_tx_power;
+    uint8_t mfg_seq;
     const char *service_uuid_view[K10_MAX_UUIDS];
     unsigned int service_uuid_view_count;
     char object_path[128];

--- a/include/k10_barrel/advertising.h
+++ b/include/k10_barrel/advertising.h
@@ -20,6 +20,8 @@ struct k10_adv_state {
     int mgmt_fd;
     uint8_t mgmt_instance;
     bool mgmt_active;
+    int hci_fd;
+    bool hci_active;
     const char *service_uuid_view[K10_MAX_UUIDS];
     unsigned int service_uuid_view_count;
     char object_path[128];

--- a/include/k10_barrel/advertising.h
+++ b/include/k10_barrel/advertising.h
@@ -15,6 +15,8 @@ struct k10_adv_state {
     bool include_manufacturer_data;
     bool include_local_name;
     bool include_tx_power;
+    const char *service_uuid_view[K10_MAX_UUIDS];
+    unsigned int service_uuid_view_count;
     char object_path[128];
     sd_bus_slot *slot;
     sd_bus_slot *pending_slot;

--- a/include/k10_barrel/advertising.h
+++ b/include/k10_barrel/advertising.h
@@ -17,6 +17,9 @@ struct k10_adv_state {
     bool include_local_name;
     bool include_tx_power;
     uint8_t mfg_seq;
+    int mgmt_fd;
+    uint8_t mgmt_instance;
+    bool mgmt_active;
     const char *service_uuid_view[K10_MAX_UUIDS];
     unsigned int service_uuid_view_count;
     char object_path[128];

--- a/include/k10_barrel/config.h
+++ b/include/k10_barrel/config.h
@@ -10,6 +10,8 @@ struct k10_config {
     char local_name[64];
     unsigned int company_id;
     char manufacturer_mac_label[32];
+    char sweeper_mfg_suffix[32];
+    char barrel_mfg_suffix[32];
     char service_uuids[K10_MAX_UUIDS][64];
     unsigned int service_uuid_count;
     char fd3d_service_data_hex[64];

--- a/include/k10_barrel/config.h
+++ b/include/k10_barrel/config.h
@@ -15,6 +15,8 @@ struct k10_config {
     char service_uuids[K10_MAX_UUIDS][64];
     unsigned int service_uuid_count;
     char fd3d_service_data_hex[64];
+    char sweeper_fd3d_service_data_hex[64];
+    char barrel_fd3d_service_data_hex[64];
     bool include_tx_power;
     unsigned int fw_major;
     unsigned int fw_minor;

--- a/include/k10_barrel/config.h
+++ b/include/k10_barrel/config.h
@@ -8,6 +8,7 @@
 struct k10_config {
     char adapter[16];
     char local_name[64];
+    char advertising_backend[16];
     unsigned int company_id;
     char manufacturer_mac_label[32];
     char sweeper_mfg_suffix[32];

--- a/include/k10_barrel/config.h
+++ b/include/k10_barrel/config.h
@@ -19,6 +19,7 @@ struct k10_config {
     char sweeper_fd3d_service_data_hex[64];
     char barrel_fd3d_service_data_hex[64];
     bool include_tx_power;
+    bool use_random_address;
     unsigned int fw_major;
     unsigned int fw_minor;
 };

--- a/include/k10_barrel/daemon.h
+++ b/include/k10_barrel/daemon.h
@@ -5,6 +5,7 @@
 
 #include "k10_barrel/advertising.h"
 #include "k10_barrel/config.h"
+#include "k10_barrel/gatt.h"
 
 enum k10_emulator_mode { K10_MODE_NONE = 0, K10_MODE_SWEEPER, K10_MODE_BARREL };
 
@@ -14,6 +15,7 @@ struct k10_daemon_state {
     bool running;
     enum k10_emulator_mode mode;
     struct k10_adv_state adv;
+    struct k10_gatt_state gatt;
 };
 
 int k10_daemon_run(void);

--- a/include/k10_barrel/daemon.h
+++ b/include/k10_barrel/daemon.h
@@ -12,7 +12,6 @@ struct k10_daemon_state {
     struct k10_config config;
     char config_path[256];
     bool running;
-    bool advertising;
     enum k10_emulator_mode mode;
     struct k10_adv_state adv;
 };

--- a/include/k10_barrel/daemon.h
+++ b/include/k10_barrel/daemon.h
@@ -3,6 +3,7 @@
 
 #include <stdbool.h>
 
+#include "k10_barrel/advertising.h"
 #include "k10_barrel/config.h"
 
 enum k10_emulator_mode { K10_MODE_NONE = 0, K10_MODE_SWEEPER, K10_MODE_BARREL };
@@ -11,7 +12,9 @@ struct k10_daemon_state {
     struct k10_config config;
     char config_path[256];
     bool running;
+    bool advertising;
     enum k10_emulator_mode mode;
+    struct k10_adv_state adv;
 };
 
 int k10_daemon_run(void);

--- a/include/k10_barrel/gatt.h
+++ b/include/k10_barrel/gatt.h
@@ -1,0 +1,32 @@
+#ifndef K10_BARREL_GATT_H
+#define K10_BARREL_GATT_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include <systemd/sd-bus.h>
+
+#include "k10_barrel/config.h"
+
+struct k10_gatt_state {
+    bool registered;
+    bool pending;
+    bool tx_notifying;
+    char app_path[128];
+    sd_bus_slot *object_manager_slot;
+    sd_bus_slot *service_slot;
+    sd_bus_slot *rx_slot;
+    sd_bus_slot *tx_slot;
+    sd_bus_slot *pending_slot;
+    struct k10_config config;
+    uint8_t rx_value[512];
+    size_t rx_len;
+    uint8_t tx_value[512];
+    size_t tx_len;
+};
+
+int k10_gatt_start(sd_bus *bus, struct k10_gatt_state *state, const struct k10_config *config);
+int k10_gatt_stop(sd_bus *bus, struct k10_gatt_state *state);
+
+#endif

--- a/packaging/dbus/ro.vilt.SwitchbotBleEmulator.conf
+++ b/packaging/dbus/ro.vilt.SwitchbotBleEmulator.conf
@@ -6,6 +6,10 @@
     <allow send_destination="ro.vilt.SwitchbotBleEmulator"/>
   </policy>
 
+  <policy user="bluetooth">
+    <allow send_destination="ro.vilt.SwitchbotBleEmulator"/>
+  </policy>
+
   <policy context="default">
     <allow send_destination="ro.vilt.SwitchbotBleEmulator"/>
   </policy>

--- a/packaging/rpm/k10-barrel-emulator.spec
+++ b/packaging/rpm/k10-barrel-emulator.spec
@@ -10,6 +10,7 @@ Source0:        %{name}-%{version}.tar.gz
 BuildRequires:  gcc
 BuildRequires:  cmake
 BuildRequires:  make
+BuildRequires:  bluez-libs-devel
 BuildRequires:  pkgconfig(libsystemd)
 BuildRequires:  systemd-rpm-macros
 

--- a/src/ble/advertising.c
+++ b/src/ble/advertising.c
@@ -599,27 +599,33 @@ static int k10_adv_hci_start(struct k10_adv_state *state, const struct k10_confi
         }
         if (k10_hci_le_set_random_address(state->hci_fd, &random_addr, 1000) == 0) {
             own_addr_type = 0x01;
+        } else {
+            k10_log_error("hci set random address failed: %s", strerror(errno));
         }
     }
 
     r = k10_hci_le_set_advertising_parameters(state->hci_fd, 0x00a0, 0x00f0, 0x00, own_addr_type,
                                               0x00, &direct_addr, 0x07, 0x00, 1000);
     if (r < 0) {
+        k10_log_error("hci set advertising parameters failed: %s", strerror(errno));
         return -errno;
     }
 
     r = k10_hci_le_set_advertising_data(state->hci_fd, (uint8_t)adv_len, adv_buffer, 1000);
     if (r < 0) {
+        k10_log_error("hci set advertising data failed: %s", strerror(errno));
         return -errno;
     }
 
     r = k10_hci_le_set_scan_response_data(state->hci_fd, (uint8_t)scan_len, scan_buffer, 1000);
     if (r < 0) {
+        k10_log_error("hci set scan response data failed: %s", strerror(errno));
         return -errno;
     }
 
     r = k10_hci_le_set_advertise_enable(state->hci_fd, 0x01, 1000);
     if (r < 0) {
+        k10_log_error("hci advertise enable failed: %s", strerror(errno));
         return -errno;
     }
 

--- a/src/ble/advertising.c
+++ b/src/ble/advertising.c
@@ -41,8 +41,19 @@ struct k10_hex_bytes {
     size_t length;
 };
 
+static int k10_adv_append_ad(uint8_t *buffer, size_t *buffer_len, uint8_t ad_type,
+                             const uint8_t *data, size_t data_len);
 static uint8_t k10_adv_random_battery(void);
 static uint8_t k10_adv_next_seq(struct k10_adv_state *state);
+
+extern int hci_le_set_advertising_parameters(int dd, uint16_t min_interval, uint16_t max_interval,
+                                             uint8_t advtype, uint8_t own_bdaddr_type,
+                                             uint8_t direct_bdaddr_type,
+                                             const bdaddr_t *direct_bdaddr, uint8_t chan_map,
+                                             uint8_t filter, int to);
+extern int hci_le_set_advertising_data(int dd, uint8_t length, const uint8_t *data, int to);
+extern int hci_le_set_scan_response_data(int dd, uint8_t length, const uint8_t *data, int to);
+extern int hci_le_set_advertise_enable(int dd, uint8_t enable, int to);
 
 struct k10_mgmt_hdr {
     uint16_t opcode;
@@ -558,7 +569,7 @@ static int k10_adv_hci_start(struct k10_adv_state *state, const struct k10_confi
     uint8_t scan_buffer[K10_ADV_MAX_LEN];
     size_t adv_len = 0;
     size_t scan_len = 0;
-    uint8_t direct_addr[6] = {0};
+    bdaddr_t direct_addr = {{0}};
     int r = 0;
 
     if (state == NULL || config == NULL) {
@@ -577,7 +588,7 @@ static int k10_adv_hci_start(struct k10_adv_state *state, const struct k10_confi
     }
 
     r = hci_le_set_advertising_parameters(state->hci_fd, 0x00a0, 0x00f0, 0x00, 0x00, 0x00,
-                                          direct_addr, 0x07, 0x00, 1000);
+                                          &direct_addr, 0x07, 0x00, 1000);
     if (r < 0) {
         return -errno;
     }

--- a/src/ble/advertising.c
+++ b/src/ble/advertising.c
@@ -1,0 +1,424 @@
+#include "k10_barrel/advertising.h"
+
+#include "k10_barrel/dbus_defs.h"
+#include "k10_barrel/log.h"
+
+#include <ctype.h>
+#include <errno.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <syslog.h>
+
+#define K10_BLUEZ_SERVICE "org.bluez"
+#define K10_ADV_IFACE "org.bluez.LEAdvertisement1"
+#define K10_ADV_MGR_IFACE "org.bluez.LEAdvertisingManager1"
+#define K10_ADV_OBJECT "/ro/vilt/SwitchbotBleEmulator/advertisement0"
+
+struct k10_hex_bytes {
+    uint8_t data[64];
+    size_t length;
+};
+
+static int k10_hex_value(char ch) {
+    if (ch >= '0' && ch <= '9') {
+        return ch - '0';
+    }
+    if (ch >= 'a' && ch <= 'f') {
+        return 10 + (ch - 'a');
+    }
+    if (ch >= 'A' && ch <= 'F') {
+        return 10 + (ch - 'A');
+    }
+    return -1;
+}
+
+static int k10_parse_hex_bytes(const char *hex, struct k10_hex_bytes *out) {
+    size_t length = 0;
+    int high = -1;
+
+    if (hex == NULL || out == NULL) {
+        return -1;
+    }
+
+    memset(out, 0, sizeof(*out));
+
+    for (size_t i = 0; hex[i] != '\0'; i++) {
+        char ch = hex[i];
+        int value = 0;
+
+        if (ch == ':' || ch == ' ' || ch == '\t') {
+            continue;
+        }
+
+        value = k10_hex_value(ch);
+        if (value < 0) {
+            return -1;
+        }
+
+        if (high < 0) {
+            high = value;
+            continue;
+        }
+
+        if (length >= sizeof(out->data)) {
+            return -1;
+        }
+
+        out->data[length++] = (uint8_t)((high << 4) | value);
+        high = -1;
+    }
+
+    if (high >= 0) {
+        return -1;
+    }
+
+    out->length = length;
+    return 0;
+}
+
+static int k10_adv_get_type(sd_bus *bus, const char *path, const char *interface,
+                            const char *property, sd_bus_message *reply, void *userdata,
+                            sd_bus_error *ret_error) {
+    (void)bus;
+    (void)path;
+    (void)interface;
+    (void)property;
+    (void)userdata;
+    (void)ret_error;
+
+    return sd_bus_message_append(reply, "s", "peripheral");
+}
+
+static int k10_adv_get_service_uuids(sd_bus *bus, const char *path, const char *interface,
+                                     const char *property, sd_bus_message *reply, void *userdata,
+                                     sd_bus_error *ret_error) {
+    struct k10_adv_state *state = userdata;
+
+    (void)bus;
+    (void)path;
+    (void)interface;
+    (void)property;
+    (void)ret_error;
+
+    int r = sd_bus_message_open_container(reply, 'a', "s");
+    if (r < 0) {
+        return r;
+    }
+
+    for (unsigned int i = 0; i < state->config.service_uuid_count; i++) {
+        r = sd_bus_message_append(reply, "s", state->config.service_uuids[i]);
+        if (r < 0) {
+            return r;
+        }
+    }
+
+    return sd_bus_message_close_container(reply);
+}
+
+static int k10_adv_append_variant_bytes(sd_bus_message *reply, const uint8_t *data, size_t length) {
+    int r = sd_bus_message_open_container(reply, 'v', "ay");
+    if (r < 0) {
+        return r;
+    }
+
+    r = sd_bus_message_append_array(reply, 'y', data, length);
+    if (r < 0) {
+        return r;
+    }
+
+    return sd_bus_message_close_container(reply);
+}
+
+static int k10_adv_get_manufacturer_data(sd_bus *bus, const char *path, const char *interface,
+                                         const char *property, sd_bus_message *reply,
+                                         void *userdata, sd_bus_error *ret_error) {
+    struct k10_adv_state *state = userdata;
+    struct k10_hex_bytes bytes = {0};
+
+    (void)bus;
+    (void)path;
+    (void)interface;
+    (void)property;
+    (void)ret_error;
+
+    int r = sd_bus_message_open_container(reply, 'a', "{qv}");
+    if (r < 0) {
+        return r;
+    }
+
+    if (state->config.manufacturer_mac_label[0] != '\0') {
+        if (k10_parse_hex_bytes(state->config.manufacturer_mac_label, &bytes) == 0 &&
+            bytes.length > 0) {
+            r = sd_bus_message_open_container(reply, 'e', "qv");
+            if (r < 0) {
+                return r;
+            }
+
+            r = sd_bus_message_append(reply, "q", (uint16_t)state->config.company_id);
+            if (r < 0) {
+                return r;
+            }
+
+            r = k10_adv_append_variant_bytes(reply, bytes.data, bytes.length);
+            if (r < 0) {
+                return r;
+            }
+
+            r = sd_bus_message_close_container(reply);
+            if (r < 0) {
+                return r;
+            }
+        }
+    }
+
+    return sd_bus_message_close_container(reply);
+}
+
+static int k10_adv_get_service_data(sd_bus *bus, const char *path, const char *interface,
+                                    const char *property, sd_bus_message *reply, void *userdata,
+                                    sd_bus_error *ret_error) {
+    struct k10_adv_state *state = userdata;
+    struct k10_hex_bytes bytes = {0};
+
+    (void)bus;
+    (void)path;
+    (void)interface;
+    (void)property;
+    (void)ret_error;
+
+    int r = sd_bus_message_open_container(reply, 'a', "{sv}");
+    if (r < 0) {
+        return r;
+    }
+
+    if (state->config.fd3d_service_data_hex[0] != '\0') {
+        if (k10_parse_hex_bytes(state->config.fd3d_service_data_hex, &bytes) == 0 &&
+            bytes.length > 0) {
+            r = sd_bus_message_open_container(reply, 'e', "sv");
+            if (r < 0) {
+                return r;
+            }
+
+            r = sd_bus_message_append(reply, "s", "FD3D");
+            if (r < 0) {
+                return r;
+            }
+
+            r = k10_adv_append_variant_bytes(reply, bytes.data, bytes.length);
+            if (r < 0) {
+                return r;
+            }
+
+            r = sd_bus_message_close_container(reply);
+            if (r < 0) {
+                return r;
+            }
+        }
+    }
+
+    return sd_bus_message_close_container(reply);
+}
+
+static int k10_adv_get_includes(sd_bus *bus, const char *path, const char *interface,
+                                const char *property, sd_bus_message *reply, void *userdata,
+                                sd_bus_error *ret_error) {
+    struct k10_adv_state *state = userdata;
+
+    (void)bus;
+    (void)path;
+    (void)interface;
+    (void)property;
+    (void)ret_error;
+
+    int r = sd_bus_message_open_container(reply, 'a', "s");
+    if (r < 0) {
+        return r;
+    }
+
+    if (state->config.include_tx_power) {
+        r = sd_bus_message_append(reply, "s", "tx-power");
+        if (r < 0) {
+            return r;
+        }
+    }
+
+    return sd_bus_message_close_container(reply);
+}
+
+static int k10_adv_get_local_name(sd_bus *bus, const char *path, const char *interface,
+                                  const char *property, sd_bus_message *reply, void *userdata,
+                                  sd_bus_error *ret_error) {
+    struct k10_adv_state *state = userdata;
+
+    (void)bus;
+    (void)path;
+    (void)interface;
+    (void)property;
+    (void)ret_error;
+
+    return sd_bus_message_append(reply, "s", state->config.local_name);
+}
+
+static int k10_adv_get_discoverable(sd_bus *bus, const char *path, const char *interface,
+                                    const char *property, sd_bus_message *reply, void *userdata,
+                                    sd_bus_error *ret_error) {
+    (void)bus;
+    (void)path;
+    (void)interface;
+    (void)property;
+    (void)userdata;
+    (void)ret_error;
+
+    return sd_bus_message_append(reply, "b", 1);
+}
+
+static int k10_adv_release(sd_bus_message *m, void *userdata, sd_bus_error *ret_error) {
+    struct k10_adv_state *state = userdata;
+
+    (void)ret_error;
+
+    state->registered = false;
+    k10_log_info("advertising released by BlueZ");
+
+    return sd_bus_reply_method_return(m, "");
+}
+
+static const sd_bus_vtable k10_adv_vtable[] = {
+    SD_BUS_VTABLE_START(0),
+    SD_BUS_METHOD("Release", "", "", k10_adv_release, SD_BUS_VTABLE_UNPRIVILEGED),
+    SD_BUS_PROPERTY("Type", "s", k10_adv_get_type, 0, SD_BUS_VTABLE_PROPERTY_CONST),
+    SD_BUS_PROPERTY("ServiceUUIDs", "as", k10_adv_get_service_uuids, 0,
+                    SD_BUS_VTABLE_PROPERTY_CONST),
+    SD_BUS_PROPERTY("ManufacturerData", "a{qv}", k10_adv_get_manufacturer_data, 0,
+                    SD_BUS_VTABLE_PROPERTY_CONST),
+    SD_BUS_PROPERTY("ServiceData", "a{sv}", k10_adv_get_service_data, 0,
+                    SD_BUS_VTABLE_PROPERTY_CONST),
+    SD_BUS_PROPERTY("Includes", "as", k10_adv_get_includes, 0, SD_BUS_VTABLE_PROPERTY_CONST),
+    SD_BUS_PROPERTY("LocalName", "s", k10_adv_get_local_name, 0, SD_BUS_VTABLE_PROPERTY_CONST),
+    SD_BUS_PROPERTY("Discoverable", "b", k10_adv_get_discoverable, 0, SD_BUS_VTABLE_PROPERTY_CONST),
+    SD_BUS_VTABLE_END};
+
+static void k10_adv_set_defaults(struct k10_adv_state *state) {
+    if (state->object_path[0] == '\0') {
+        strncpy(state->object_path, K10_ADV_OBJECT, sizeof(state->object_path) - 1);
+    }
+}
+
+static int k10_adv_register(sd_bus *bus, struct k10_adv_state *state, const char *adapter) {
+    sd_bus_error error = SD_BUS_ERROR_NULL;
+    sd_bus_message *message = NULL;
+    sd_bus_message *reply = NULL;
+    char adapter_path[128];
+    int r = 0;
+
+    snprintf(adapter_path, sizeof(adapter_path), "/org/bluez/%s", adapter);
+
+    r = sd_bus_message_new_method_call(bus, &message, K10_BLUEZ_SERVICE, adapter_path,
+                                       K10_ADV_MGR_IFACE, "RegisterAdvertisement");
+    if (r < 0) {
+        return r;
+    }
+
+    r = sd_bus_message_append(message, "o", state->object_path);
+    if (r < 0) {
+        goto finish;
+    }
+
+    r = sd_bus_message_open_container(message, 'a', "{sv}");
+    if (r < 0) {
+        goto finish;
+    }
+
+    r = sd_bus_message_close_container(message);
+    if (r < 0) {
+        goto finish;
+    }
+
+    r = sd_bus_call(bus, message, 0, &error, &reply);
+    if (r < 0) {
+        k10_log_error("advertising register failed: %s",
+                      error.message ? error.message : strerror(-r));
+    }
+
+finish:
+    sd_bus_error_free(&error);
+    sd_bus_message_unref(reply);
+    sd_bus_message_unref(message);
+    return r;
+}
+
+static int k10_adv_unregister(sd_bus *bus, const struct k10_adv_state *state, const char *adapter) {
+    sd_bus_error error = SD_BUS_ERROR_NULL;
+    sd_bus_message *reply = NULL;
+    char adapter_path[128];
+    int r = 0;
+
+    snprintf(adapter_path, sizeof(adapter_path), "/org/bluez/%s", adapter);
+
+    r = sd_bus_call_method(bus, K10_BLUEZ_SERVICE, adapter_path, K10_ADV_MGR_IFACE,
+                           "UnregisterAdvertisement", &error, &reply, "o", state->object_path);
+    if (r < 0) {
+        k10_log_error("advertising unregister failed: %s",
+                      error.message ? error.message : strerror(-r));
+    }
+
+    sd_bus_error_free(&error);
+    sd_bus_message_unref(reply);
+    return r;
+}
+
+int k10_adv_start(sd_bus *bus, struct k10_adv_state *state, const struct k10_config *config) {
+    int r = 0;
+
+    if (bus == NULL || state == NULL || config == NULL) {
+        return -EINVAL;
+    }
+
+    if (state->registered) {
+        return 0;
+    }
+
+    k10_adv_set_defaults(state);
+    state->config = *config;
+
+    if (state->slot == NULL) {
+        r = sd_bus_add_object_vtable(bus, &state->slot, state->object_path, K10_ADV_IFACE,
+                                     k10_adv_vtable, state);
+        if (r < 0) {
+            k10_log_error("advertising vtable failed: %s", strerror(-r));
+            return r;
+        }
+    }
+
+    r = k10_adv_register(bus, state, config->adapter);
+    if (r < 0) {
+        sd_bus_slot_unref(state->slot);
+        state->slot = NULL;
+        return r;
+    }
+
+    state->registered = true;
+    k10_log_info("advertising registered on %s", config->adapter);
+    return 0;
+}
+
+int k10_adv_stop(sd_bus *bus, struct k10_adv_state *state) {
+    int r = 0;
+
+    if (bus == NULL || state == NULL) {
+        return -EINVAL;
+    }
+
+    if (!state->registered) {
+        return 0;
+    }
+
+    r = k10_adv_unregister(bus, state, state->config.adapter);
+    sd_bus_slot_unref(state->slot);
+    state->slot = NULL;
+    state->registered = false;
+
+    k10_log_info("advertising unregistered");
+    return r;
+}

--- a/src/ble/advertising.c
+++ b/src/ble/advertising.c
@@ -372,10 +372,7 @@ static int k10_adv_mgmt_start(struct k10_adv_state *state, const struct k10_conf
 
     if (state->include_local_name && config->local_name[0] != '\0') {
         size_t name_len = strlen(config->local_name);
-        if (k10_adv_append_ad(adv_buffer,
-                              &adv_len,
-                              0x09,
-                              (const uint8_t *)config->local_name,
+        if (k10_adv_append_ad(adv_buffer, &adv_len, 0x09, (const uint8_t *)config->local_name,
                               name_len) != 0) {
             k10_log_error("mgmt adv data too large (name)");
             return -EINVAL;

--- a/src/ble/advertising.c
+++ b/src/ble/advertising.c
@@ -697,8 +697,8 @@ static int k10_hci_le_set_advertising_data(int dd, uint8_t length, const uint8_t
         memcpy(cp.data, data, length);
     }
 
-    if (k10_hci_send_req(dd, OCF_LE_SET_ADVERTISING_DATA, &cp, LE_SET_ADVERTISING_DATA_CP_SIZE,
-                         &rp, LE_SET_ADVERTISING_DATA_RP_SIZE, to) < 0) {
+    if (k10_hci_send_req(dd, OCF_LE_SET_ADVERTISING_DATA, &cp, LE_SET_ADVERTISING_DATA_CP_SIZE, &rp,
+                         LE_SET_ADVERTISING_DATA_RP_SIZE, to) < 0) {
         return -1;
     }
 
@@ -710,8 +710,7 @@ static int k10_hci_le_set_advertising_data(int dd, uint8_t length, const uint8_t
     return 0;
 }
 
-static int k10_hci_le_set_scan_response_data(int dd, uint8_t length, const uint8_t *data,
-                                             int to) {
+static int k10_hci_le_set_scan_response_data(int dd, uint8_t length, const uint8_t *data, int to) {
     le_set_scan_response_data_cp cp;
     le_set_scan_response_data_rp rp;
 
@@ -724,9 +723,8 @@ static int k10_hci_le_set_scan_response_data(int dd, uint8_t length, const uint8
         memcpy(cp.data, data, length);
     }
 
-    if (k10_hci_send_req(dd, OCF_LE_SET_SCAN_RESPONSE_DATA, &cp,
-                         LE_SET_SCAN_RESPONSE_DATA_CP_SIZE, &rp,
-                         LE_SET_SCAN_RESPONSE_DATA_RP_SIZE, to) < 0) {
+    if (k10_hci_send_req(dd, OCF_LE_SET_SCAN_RESPONSE_DATA, &cp, LE_SET_SCAN_RESPONSE_DATA_CP_SIZE,
+                         &rp, LE_SET_SCAN_RESPONSE_DATA_RP_SIZE, to) < 0) {
         return -1;
     }
 
@@ -744,8 +742,8 @@ static int k10_hci_le_set_advertise_enable(int dd, uint8_t enable, int to) {
 
     cp.enable = enable;
 
-    if (k10_hci_send_req(dd, OCF_LE_SET_ADVERTISE_ENABLE, &cp, LE_SET_ADVERTISE_ENABLE_CP_SIZE,
-                         &rp, LE_SET_ADVERTISE_ENABLE_RP_SIZE, to) < 0) {
+    if (k10_hci_send_req(dd, OCF_LE_SET_ADVERTISE_ENABLE, &cp, LE_SET_ADVERTISE_ENABLE_CP_SIZE, &rp,
+                         LE_SET_ADVERTISE_ENABLE_RP_SIZE, to) < 0) {
         return -1;
     }
 

--- a/src/ble/advertising.c
+++ b/src/ble/advertising.c
@@ -124,13 +124,16 @@ static size_t k10_adv_uuid_list_length(const struct k10_config *config) {
         }
     }
 
-    return (count16 ? (2 + 2 * count16) : 0) + (count32 ? (2 + 4 * count32) : 0) +
+    return (count16 ? (2 + 2 * count16) : 0) +
+           (count32 ? (2 + 4 * count32) : 0) +
            (count128 ? (2 + 16 * count128) : 0);
 }
 
 static size_t k10_adv_estimated_length(const struct k10_config *config,
-                                       bool include_service_uuids, bool include_service_data,
-                                       bool include_manufacturer, bool include_local_name,
+                                       bool include_service_uuids,
+                                       bool include_service_data,
+                                       bool include_manufacturer,
+                                       bool include_local_name,
                                        bool include_tx_power) {
     struct k10_hex_bytes bytes = {0};
     size_t length = K10_ADV_FLAGS_LEN;
@@ -144,12 +147,14 @@ static size_t k10_adv_estimated_length(const struct k10_config *config,
     }
 
     if (include_manufacturer && config->manufacturer_mac_label[0] != '\0' &&
-        k10_parse_hex_bytes(config->manufacturer_mac_label, &bytes) == 0 && bytes.length > 0) {
+        k10_parse_hex_bytes(config->manufacturer_mac_label, &bytes) == 0 &&
+        bytes.length > 0) {
         length += 4 + bytes.length;
     }
 
     if (include_service_data && config->fd3d_service_data_hex[0] != '\0' &&
-        k10_parse_hex_bytes(config->fd3d_service_data_hex, &bytes) == 0 && bytes.length > 0) {
+        k10_parse_hex_bytes(config->fd3d_service_data_hex, &bytes) == 0 &&
+        bytes.length > 0) {
         length += 4 + bytes.length;
     }
 
@@ -169,53 +174,66 @@ static void k10_adv_select_fields(struct k10_adv_state *state) {
     state->include_local_name = state->config.local_name[0] != '\0';
     state->include_tx_power = state->config.include_tx_power;
 
-    length = k10_adv_estimated_length(&state->config, state->include_service_uuids,
-                                      state->include_service_data, state->include_manufacturer_data,
-                                      state->include_local_name, state->include_tx_power);
+    length = k10_adv_estimated_length(&state->config,
+                                      state->include_service_uuids,
+                                      state->include_service_data,
+                                      state->include_manufacturer_data,
+                                      state->include_local_name,
+                                      state->include_tx_power);
 
     if (length > K10_ADV_MAX_LEN && state->include_service_uuids) {
-        k10_log_warn("advertising payload too large (%zu); disabling service UUIDs", length);
+        k10_log_info("advertising payload too large (%zu); disabling service UUIDs", length);
         state->include_service_uuids = false;
-        length = k10_adv_estimated_length(&state->config, state->include_service_uuids,
+        length = k10_adv_estimated_length(&state->config,
+                                          state->include_service_uuids,
                                           state->include_service_data,
                                           state->include_manufacturer_data,
-                                          state->include_local_name, state->include_tx_power);
+                                          state->include_local_name,
+                                          state->include_tx_power);
     }
 
     if (length > K10_ADV_MAX_LEN && state->include_service_data) {
-        k10_log_warn("advertising payload too large (%zu); disabling service data", length);
+        k10_log_info("advertising payload too large (%zu); disabling service data", length);
         state->include_service_data = false;
-        length = k10_adv_estimated_length(&state->config, state->include_service_uuids,
+        length = k10_adv_estimated_length(&state->config,
+                                          state->include_service_uuids,
                                           state->include_service_data,
                                           state->include_manufacturer_data,
-                                          state->include_local_name, state->include_tx_power);
+                                          state->include_local_name,
+                                          state->include_tx_power);
     }
 
     if (length > K10_ADV_MAX_LEN && state->include_manufacturer_data) {
-        k10_log_warn("advertising payload too large (%zu); disabling manufacturer data", length);
+        k10_log_info("advertising payload too large (%zu); disabling manufacturer data", length);
         state->include_manufacturer_data = false;
-        length = k10_adv_estimated_length(&state->config, state->include_service_uuids,
+        length = k10_adv_estimated_length(&state->config,
+                                          state->include_service_uuids,
                                           state->include_service_data,
                                           state->include_manufacturer_data,
-                                          state->include_local_name, state->include_tx_power);
+                                          state->include_local_name,
+                                          state->include_tx_power);
     }
 
     if (length > K10_ADV_MAX_LEN && state->include_tx_power) {
-        k10_log_warn("advertising payload too large (%zu); disabling TX power", length);
+        k10_log_info("advertising payload too large (%zu); disabling TX power", length);
         state->include_tx_power = false;
-        length = k10_adv_estimated_length(&state->config, state->include_service_uuids,
+        length = k10_adv_estimated_length(&state->config,
+                                          state->include_service_uuids,
                                           state->include_service_data,
                                           state->include_manufacturer_data,
-                                          state->include_local_name, state->include_tx_power);
+                                          state->include_local_name,
+                                          state->include_tx_power);
     }
 
     if (length > K10_ADV_MAX_LEN && state->include_local_name) {
-        k10_log_warn("advertising payload too large (%zu); disabling local name", length);
+        k10_log_info("advertising payload too large (%zu); disabling local name", length);
         state->include_local_name = false;
-        length = k10_adv_estimated_length(&state->config, state->include_service_uuids,
+        length = k10_adv_estimated_length(&state->config,
+                                          state->include_service_uuids,
                                           state->include_service_data,
                                           state->include_manufacturer_data,
-                                          state->include_local_name, state->include_tx_power);
+                                          state->include_local_name,
+                                          state->include_tx_power);
     }
 
     if (length > K10_ADV_MAX_LEN) {

--- a/src/ble/advertising.c
+++ b/src/ble/advertising.c
@@ -592,11 +592,12 @@ static int k10_adv_hci_start(struct k10_adv_state *state, const struct k10_confi
         return -EINVAL;
     }
 
-    if (config->manufacturer_mac_label[0] != '\0' &&
+    if (config->use_random_address && config->manufacturer_mac_label[0] != '\0' &&
         k10_parse_hex_bytes(config->manufacturer_mac_label, &bytes) == 0 && bytes.length >= 6) {
         for (size_t i = 0; i < 6; i++) {
             random_addr.b[i] = bytes.data[5 - i];
         }
+        random_addr.b[5] = (uint8_t)((random_addr.b[5] & 0x3f) | 0xc0);
         if (k10_hci_le_set_random_address(state->hci_fd, &random_addr, 1000) == 0) {
             own_addr_type = 0x01;
         } else {

--- a/src/ble/advertising.c
+++ b/src/ble/advertising.c
@@ -656,7 +656,7 @@ static int k10_hci_le_set_advertising_parameters(int dd, uint16_t min_interval,
                                                  const bdaddr_t *direct_bdaddr, uint8_t chan_map,
                                                  uint8_t filter, int to) {
     le_set_advertising_parameters_cp cp;
-    le_set_advertising_parameters_rp rp;
+    uint8_t status = 0;
 
     memset(&cp, 0, sizeof(cp));
     cp.min_interval = htobs(min_interval);
@@ -671,12 +671,11 @@ static int k10_hci_le_set_advertising_parameters(int dd, uint16_t min_interval,
     cp.filter = filter;
 
     if (k10_hci_send_req(dd, OCF_LE_SET_ADVERTISING_PARAMETERS, &cp,
-                         LE_SET_ADVERTISING_PARAMETERS_CP_SIZE, &rp,
-                         LE_SET_ADVERTISING_PARAMETERS_RP_SIZE, to) < 0) {
+                         LE_SET_ADVERTISING_PARAMETERS_CP_SIZE, &status, sizeof(status), to) < 0) {
         return -1;
     }
 
-    if (rp.status) {
+    if (status) {
         errno = EIO;
         return -1;
     }
@@ -686,7 +685,7 @@ static int k10_hci_le_set_advertising_parameters(int dd, uint16_t min_interval,
 
 static int k10_hci_le_set_advertising_data(int dd, uint8_t length, const uint8_t *data, int to) {
     le_set_advertising_data_cp cp;
-    le_set_advertising_data_rp rp;
+    uint8_t status = 0;
 
     memset(&cp, 0, sizeof(cp));
     if (length > sizeof(cp.data)) {
@@ -697,12 +696,12 @@ static int k10_hci_le_set_advertising_data(int dd, uint8_t length, const uint8_t
         memcpy(cp.data, data, length);
     }
 
-    if (k10_hci_send_req(dd, OCF_LE_SET_ADVERTISING_DATA, &cp, LE_SET_ADVERTISING_DATA_CP_SIZE, &rp,
-                         LE_SET_ADVERTISING_DATA_RP_SIZE, to) < 0) {
+    if (k10_hci_send_req(dd, OCF_LE_SET_ADVERTISING_DATA, &cp, LE_SET_ADVERTISING_DATA_CP_SIZE,
+                         &status, sizeof(status), to) < 0) {
         return -1;
     }
 
-    if (rp.status) {
+    if (status) {
         errno = EIO;
         return -1;
     }
@@ -712,7 +711,7 @@ static int k10_hci_le_set_advertising_data(int dd, uint8_t length, const uint8_t
 
 static int k10_hci_le_set_scan_response_data(int dd, uint8_t length, const uint8_t *data, int to) {
     le_set_scan_response_data_cp cp;
-    le_set_scan_response_data_rp rp;
+    uint8_t status = 0;
 
     memset(&cp, 0, sizeof(cp));
     if (length > sizeof(cp.data)) {
@@ -724,11 +723,11 @@ static int k10_hci_le_set_scan_response_data(int dd, uint8_t length, const uint8
     }
 
     if (k10_hci_send_req(dd, OCF_LE_SET_SCAN_RESPONSE_DATA, &cp, LE_SET_SCAN_RESPONSE_DATA_CP_SIZE,
-                         &rp, LE_SET_SCAN_RESPONSE_DATA_RP_SIZE, to) < 0) {
+                         &status, sizeof(status), to) < 0) {
         return -1;
     }
 
-    if (rp.status) {
+    if (status) {
         errno = EIO;
         return -1;
     }
@@ -738,16 +737,16 @@ static int k10_hci_le_set_scan_response_data(int dd, uint8_t length, const uint8
 
 static int k10_hci_le_set_advertise_enable(int dd, uint8_t enable, int to) {
     le_set_advertise_enable_cp cp;
-    le_set_advertise_enable_rp rp;
+    uint8_t status = 0;
 
     cp.enable = enable;
 
-    if (k10_hci_send_req(dd, OCF_LE_SET_ADVERTISE_ENABLE, &cp, LE_SET_ADVERTISE_ENABLE_CP_SIZE, &rp,
-                         LE_SET_ADVERTISE_ENABLE_RP_SIZE, to) < 0) {
+    if (k10_hci_send_req(dd, OCF_LE_SET_ADVERTISE_ENABLE, &cp, LE_SET_ADVERTISE_ENABLE_CP_SIZE,
+                         &status, sizeof(status), to) < 0) {
         return -1;
     }
 
-    if (rp.status) {
+    if (status) {
         errno = EIO;
         return -1;
     }

--- a/src/ble/advertising.c
+++ b/src/ble/advertising.c
@@ -14,6 +14,8 @@
 #define K10_ADV_IFACE "org.bluez.LEAdvertisement1"
 #define K10_ADV_MGR_IFACE "org.bluez.LEAdvertisingManager1"
 #define K10_ADV_OBJECT "/ro/vilt/SwitchbotBleEmulator/advertisement0"
+#define K10_ADV_MAX_LEN 31
+#define K10_ADV_FLAGS_LEN 3
 
 struct k10_hex_bytes {
     uint8_t data[64];
@@ -77,6 +79,150 @@ static int k10_parse_hex_bytes(const char *hex, struct k10_hex_bytes *out) {
     return 0;
 }
 
+static bool k10_uuid_is_hex(const char *uuid) {
+    for (size_t i = 0; uuid[i] != '\0'; i++) {
+        if (k10_hex_value(uuid[i]) < 0) {
+            return false;
+        }
+    }
+    return true;
+}
+
+static size_t k10_uuid_bytes(const char *uuid) {
+    size_t len = 0;
+
+    if (uuid == NULL) {
+        return 0;
+    }
+
+    len = strlen(uuid);
+    if ((len == 4 || len == 8) && k10_uuid_is_hex(uuid)) {
+        return len / 2;
+    }
+    if (len == 32) {
+        return 16;
+    }
+    if (len == 36) {
+        return 16;
+    }
+    return 16;
+}
+
+static size_t k10_adv_uuid_list_length(const struct k10_config *config) {
+    size_t count16 = 0;
+    size_t count32 = 0;
+    size_t count128 = 0;
+
+    for (unsigned int i = 0; i < config->service_uuid_count; i++) {
+        size_t bytes = k10_uuid_bytes(config->service_uuids[i]);
+        if (bytes == 2) {
+            count16++;
+        } else if (bytes == 4) {
+            count32++;
+        } else {
+            count128++;
+        }
+    }
+
+    return (count16 ? (2 + 2 * count16) : 0) + (count32 ? (2 + 4 * count32) : 0) +
+           (count128 ? (2 + 16 * count128) : 0);
+}
+
+static size_t k10_adv_estimated_length(const struct k10_config *config,
+                                       bool include_service_uuids, bool include_service_data,
+                                       bool include_manufacturer, bool include_local_name,
+                                       bool include_tx_power) {
+    struct k10_hex_bytes bytes = {0};
+    size_t length = K10_ADV_FLAGS_LEN;
+
+    if (include_local_name && config->local_name[0] != '\0') {
+        length += 2 + strlen(config->local_name);
+    }
+
+    if (include_tx_power) {
+        length += 3;
+    }
+
+    if (include_manufacturer && config->manufacturer_mac_label[0] != '\0' &&
+        k10_parse_hex_bytes(config->manufacturer_mac_label, &bytes) == 0 && bytes.length > 0) {
+        length += 4 + bytes.length;
+    }
+
+    if (include_service_data && config->fd3d_service_data_hex[0] != '\0' &&
+        k10_parse_hex_bytes(config->fd3d_service_data_hex, &bytes) == 0 && bytes.length > 0) {
+        length += 4 + bytes.length;
+    }
+
+    if (include_service_uuids && config->service_uuid_count > 0) {
+        length += k10_adv_uuid_list_length(config);
+    }
+
+    return length;
+}
+
+static void k10_adv_select_fields(struct k10_adv_state *state) {
+    size_t length = 0;
+
+    state->include_service_uuids = state->config.service_uuid_count > 0;
+    state->include_service_data = state->config.fd3d_service_data_hex[0] != '\0';
+    state->include_manufacturer_data = state->config.manufacturer_mac_label[0] != '\0';
+    state->include_local_name = state->config.local_name[0] != '\0';
+    state->include_tx_power = state->config.include_tx_power;
+
+    length = k10_adv_estimated_length(&state->config, state->include_service_uuids,
+                                      state->include_service_data, state->include_manufacturer_data,
+                                      state->include_local_name, state->include_tx_power);
+
+    if (length > K10_ADV_MAX_LEN && state->include_service_uuids) {
+        k10_log_warn("advertising payload too large (%zu); disabling service UUIDs", length);
+        state->include_service_uuids = false;
+        length = k10_adv_estimated_length(&state->config, state->include_service_uuids,
+                                          state->include_service_data,
+                                          state->include_manufacturer_data,
+                                          state->include_local_name, state->include_tx_power);
+    }
+
+    if (length > K10_ADV_MAX_LEN && state->include_service_data) {
+        k10_log_warn("advertising payload too large (%zu); disabling service data", length);
+        state->include_service_data = false;
+        length = k10_adv_estimated_length(&state->config, state->include_service_uuids,
+                                          state->include_service_data,
+                                          state->include_manufacturer_data,
+                                          state->include_local_name, state->include_tx_power);
+    }
+
+    if (length > K10_ADV_MAX_LEN && state->include_manufacturer_data) {
+        k10_log_warn("advertising payload too large (%zu); disabling manufacturer data", length);
+        state->include_manufacturer_data = false;
+        length = k10_adv_estimated_length(&state->config, state->include_service_uuids,
+                                          state->include_service_data,
+                                          state->include_manufacturer_data,
+                                          state->include_local_name, state->include_tx_power);
+    }
+
+    if (length > K10_ADV_MAX_LEN && state->include_tx_power) {
+        k10_log_warn("advertising payload too large (%zu); disabling TX power", length);
+        state->include_tx_power = false;
+        length = k10_adv_estimated_length(&state->config, state->include_service_uuids,
+                                          state->include_service_data,
+                                          state->include_manufacturer_data,
+                                          state->include_local_name, state->include_tx_power);
+    }
+
+    if (length > K10_ADV_MAX_LEN && state->include_local_name) {
+        k10_log_warn("advertising payload too large (%zu); disabling local name", length);
+        state->include_local_name = false;
+        length = k10_adv_estimated_length(&state->config, state->include_service_uuids,
+                                          state->include_service_data,
+                                          state->include_manufacturer_data,
+                                          state->include_local_name, state->include_tx_power);
+    }
+
+    if (length > K10_ADV_MAX_LEN) {
+        k10_log_error("advertising payload still too large (%zu)", length);
+    }
+}
+
 static int k10_adv_get_type(sd_bus *bus, const char *path, const char *interface,
                             const char *property, sd_bus_message *reply, void *userdata,
                             sd_bus_error *ret_error) {
@@ -106,10 +252,12 @@ static int k10_adv_get_service_uuids(sd_bus *bus, const char *path, const char *
         return r;
     }
 
-    for (unsigned int i = 0; i < state->config.service_uuid_count; i++) {
-        r = sd_bus_message_append(reply, "s", state->config.service_uuids[i]);
-        if (r < 0) {
-            return r;
+    if (state->include_service_uuids) {
+        for (unsigned int i = 0; i < state->config.service_uuid_count; i++) {
+            r = sd_bus_message_append(reply, "s", state->config.service_uuids[i]);
+            if (r < 0) {
+                return r;
+            }
         }
     }
 
@@ -147,7 +295,7 @@ static int k10_adv_get_manufacturer_data(sd_bus *bus, const char *path, const ch
         return r;
     }
 
-    if (state->config.manufacturer_mac_label[0] != '\0') {
+    if (state->include_manufacturer_data && state->config.manufacturer_mac_label[0] != '\0') {
         if (k10_parse_hex_bytes(state->config.manufacturer_mac_label, &bytes) == 0 &&
             bytes.length > 0) {
             r = sd_bus_message_open_container(reply, 'e', "qv");
@@ -192,7 +340,7 @@ static int k10_adv_get_service_data(sd_bus *bus, const char *path, const char *i
         return r;
     }
 
-    if (state->config.fd3d_service_data_hex[0] != '\0') {
+    if (state->include_service_data && state->config.fd3d_service_data_hex[0] != '\0') {
         if (k10_parse_hex_bytes(state->config.fd3d_service_data_hex, &bytes) == 0 &&
             bytes.length > 0) {
             r = sd_bus_message_open_container(reply, 'e', "sv");
@@ -236,7 +384,7 @@ static int k10_adv_get_includes(sd_bus *bus, const char *path, const char *inter
         return r;
     }
 
-    if (state->config.include_tx_power) {
+    if (state->include_tx_power) {
         r = sd_bus_message_append(reply, "s", "tx-power");
         if (r < 0) {
             return r;
@@ -256,6 +404,10 @@ static int k10_adv_get_local_name(sd_bus *bus, const char *path, const char *int
     (void)interface;
     (void)property;
     (void)ret_error;
+
+    if (!state->include_local_name) {
+        return sd_bus_message_append(reply, "s", "");
+    }
 
     return sd_bus_message_append(reply, "s", state->config.local_name);
 }
@@ -399,6 +551,7 @@ int k10_adv_start(sd_bus *bus, struct k10_adv_state *state, const struct k10_con
 
     k10_adv_set_defaults(state);
     state->config = *config;
+    k10_adv_select_fields(state);
 
     if (state->slot == NULL) {
         r = sd_bus_add_object_vtable(bus, &state->slot, state->object_path, K10_ADV_IFACE,

--- a/src/ble/advertising.c
+++ b/src/ble/advertising.c
@@ -418,8 +418,8 @@ static int k10_adv_mgmt_start(struct k10_adv_state *state, const struct k10_conf
     params.flags = 0x00010001;
     params.duration = 0;
     params.timeout = 0;
-    params.min_interval = 0;
-    params.max_interval = 0;
+    params.min_interval = 0x00a0;
+    params.max_interval = 0x00f0;
     params.tx_power = 0;
 
     r = k10_mgmt_send_cmd(state->mgmt_fd, K10_MGMT_OP_ADD_EXT_ADV_PARAMS, index, &params,

--- a/src/ble/advertising.c
+++ b/src/ble/advertising.c
@@ -40,6 +40,9 @@ struct k10_hex_bytes {
     size_t length;
 };
 
+static uint8_t k10_adv_random_battery(void);
+static uint8_t k10_adv_next_seq(struct k10_adv_state *state);
+
 struct k10_mgmt_hdr {
     uint16_t opcode;
     uint16_t index;
@@ -369,8 +372,11 @@ static int k10_adv_mgmt_start(struct k10_adv_state *state, const struct k10_conf
 
     if (state->include_local_name && config->local_name[0] != '\0') {
         size_t name_len = strlen(config->local_name);
-        if (k10_adv_append_ad(adv_buffer, &adv_len, 0x09,
-                              (const uint8_t *)config->local_name, name_len) != 0) {
+        if (k10_adv_append_ad(adv_buffer,
+                              &adv_len,
+                              0x09,
+                              (const uint8_t *)config->local_name,
+                              name_len) != 0) {
             k10_log_error("mgmt adv data too large (name)");
             return -EINVAL;
         }

--- a/src/ble/advertising.c
+++ b/src/ble/advertising.c
@@ -190,6 +190,9 @@ static void k10_adv_select_fields(struct k10_adv_state *state) {
     state->include_local_name = state->config.local_name[0] != '\0';
     state->include_tx_power = state->config.include_tx_power;
 
+    state->service_uuid_view_count = 0;
+    state->include_service_uuids = false;
+
     length = k10_adv_estimated_length(&state->config, state, state->include_service_uuids,
                                       state->include_service_data, state->include_manufacturer_data,
                                       state->include_local_name, state->include_tx_power);

--- a/src/ble/advertising.c
+++ b/src/ble/advertising.c
@@ -476,53 +476,11 @@ static int k10_adv_get_local_name(sd_bus *bus, const char *path, const char *int
     (void)property;
     (void)ret_error;
 
-    (void)state;
-    return sd_bus_message_append(reply, "s", "");
-}
-
-static int k10_adv_get_data(sd_bus *bus, const char *path, const char *interface,
-                            const char *property, sd_bus_message *reply, void *userdata,
-                            sd_bus_error *ret_error) {
-    struct k10_adv_state *state = userdata;
-    int r = 0;
-
-    (void)bus;
-    (void)path;
-    (void)interface;
-    (void)property;
-    (void)ret_error;
-
-    r = sd_bus_message_open_container(reply, 'a', "{yv}");
-    if (r < 0) {
-        return r;
+    if (!state->include_local_name) {
+        return sd_bus_message_append(reply, "s", "");
     }
 
-    if (state->include_local_name && state->config.local_name[0] != '\0') {
-        size_t name_len = strlen(state->config.local_name);
-
-        r = sd_bus_message_open_container(reply, 'e', "yv");
-        if (r < 0) {
-            return r;
-        }
-
-        r = sd_bus_message_append(reply, "y", (uint8_t)0x09);
-        if (r < 0) {
-            return r;
-        }
-
-        r = k10_adv_append_variant_bytes(reply, (const uint8_t *)state->config.local_name,
-                                         name_len);
-        if (r < 0) {
-            return r;
-        }
-
-        r = sd_bus_message_close_container(reply);
-        if (r < 0) {
-            return r;
-        }
-    }
-
-    return sd_bus_message_close_container(reply);
+    return sd_bus_message_append(reply, "s", state->config.local_name);
 }
 
 static int k10_adv_get_discoverable(sd_bus *bus, const char *path, const char *interface,
@@ -559,7 +517,6 @@ static const sd_bus_vtable k10_adv_vtable[] = {
                     SD_BUS_VTABLE_PROPERTY_CONST),
     SD_BUS_PROPERTY("ServiceData", "a{sv}", k10_adv_get_service_data, 0,
                     SD_BUS_VTABLE_PROPERTY_CONST),
-    SD_BUS_PROPERTY("Data", "a{yv}", k10_adv_get_data, 0, SD_BUS_VTABLE_PROPERTY_CONST),
     SD_BUS_PROPERTY("Includes", "as", k10_adv_get_includes, 0, SD_BUS_VTABLE_PROPERTY_CONST),
     SD_BUS_PROPERTY("LocalName", "s", k10_adv_get_local_name, 0, SD_BUS_VTABLE_PROPERTY_CONST),
     SD_BUS_PROPERTY("Discoverable", "b", k10_adv_get_discoverable, 0, SD_BUS_VTABLE_PROPERTY_CONST),

--- a/src/ble/advertising.c
+++ b/src/ble/advertising.c
@@ -605,6 +605,8 @@ static int k10_adv_hci_start(struct k10_adv_state *state, const struct k10_confi
         }
     }
 
+    (void)k10_hci_le_set_advertise_enable(state->hci_fd, 0x00, 1000);
+
     r = k10_hci_le_set_advertising_parameters(state->hci_fd, 0x00a0, 0x00f0, 0x00, own_addr_type,
                                               0x00, &direct_addr, 0x07, 0x00, 1000);
     if (r < 0) {
@@ -697,6 +699,7 @@ static int k10_hci_le_set_advertising_parameters(int dd, uint16_t min_interval,
     }
 
     if (status) {
+        k10_log_error("hci set advertising parameters status: 0x%02x", status);
         errno = EIO;
         return -1;
     }
@@ -723,6 +726,7 @@ static int k10_hci_le_set_advertising_data(int dd, uint8_t length, const uint8_t
     }
 
     if (status) {
+        k10_log_error("hci set advertising data status: 0x%02x", status);
         errno = EIO;
         return -1;
     }
@@ -749,6 +753,7 @@ static int k10_hci_le_set_scan_response_data(int dd, uint8_t length, const uint8
     }
 
     if (status) {
+        k10_log_error("hci set scan response data status: 0x%02x", status);
         errno = EIO;
         return -1;
     }
@@ -768,6 +773,7 @@ static int k10_hci_le_set_advertise_enable(int dd, uint8_t enable, int to) {
     }
 
     if (status) {
+        k10_log_error("hci set advertise enable status: 0x%02x", status);
         errno = EIO;
         return -1;
     }
@@ -792,6 +798,7 @@ static int k10_hci_le_set_random_address(int dd, const bdaddr_t *addr, int to) {
     }
 
     if (status) {
+        k10_log_error("hci set random address status: 0x%02x", status);
         errno = EIO;
         return -1;
     }

--- a/src/ble/advertising.c
+++ b/src/ble/advertising.c
@@ -124,17 +124,13 @@ static size_t k10_adv_uuid_list_length(const struct k10_config *config) {
         }
     }
 
-    return (count16 ? (2 + 2 * count16) : 0) +
-           (count32 ? (2 + 4 * count32) : 0) +
+    return (count16 ? (2 + 2 * count16) : 0) + (count32 ? (2 + 4 * count32) : 0) +
            (count128 ? (2 + 16 * count128) : 0);
 }
 
-static size_t k10_adv_estimated_length(const struct k10_config *config,
-                                       bool include_service_uuids,
-                                       bool include_service_data,
-                                       bool include_manufacturer,
-                                       bool include_local_name,
-                                       bool include_tx_power) {
+static size_t k10_adv_estimated_length(const struct k10_config *config, bool include_service_uuids,
+                                       bool include_service_data, bool include_manufacturer,
+                                       bool include_local_name, bool include_tx_power) {
     struct k10_hex_bytes bytes = {0};
     size_t length = K10_ADV_FLAGS_LEN;
 
@@ -147,14 +143,12 @@ static size_t k10_adv_estimated_length(const struct k10_config *config,
     }
 
     if (include_manufacturer && config->manufacturer_mac_label[0] != '\0' &&
-        k10_parse_hex_bytes(config->manufacturer_mac_label, &bytes) == 0 &&
-        bytes.length > 0) {
+        k10_parse_hex_bytes(config->manufacturer_mac_label, &bytes) == 0 && bytes.length > 0) {
         length += 4 + bytes.length;
     }
 
     if (include_service_data && config->fd3d_service_data_hex[0] != '\0' &&
-        k10_parse_hex_bytes(config->fd3d_service_data_hex, &bytes) == 0 &&
-        bytes.length > 0) {
+        k10_parse_hex_bytes(config->fd3d_service_data_hex, &bytes) == 0 && bytes.length > 0) {
         length += 4 + bytes.length;
     }
 
@@ -174,66 +168,48 @@ static void k10_adv_select_fields(struct k10_adv_state *state) {
     state->include_local_name = state->config.local_name[0] != '\0';
     state->include_tx_power = state->config.include_tx_power;
 
-    length = k10_adv_estimated_length(&state->config,
-                                      state->include_service_uuids,
-                                      state->include_service_data,
-                                      state->include_manufacturer_data,
-                                      state->include_local_name,
-                                      state->include_tx_power);
+    length = k10_adv_estimated_length(&state->config, state->include_service_uuids,
+                                      state->include_service_data, state->include_manufacturer_data,
+                                      state->include_local_name, state->include_tx_power);
 
     if (length > K10_ADV_MAX_LEN && state->include_service_uuids) {
         k10_log_info("advertising payload too large (%zu); disabling service UUIDs", length);
         state->include_service_uuids = false;
-        length = k10_adv_estimated_length(&state->config,
-                                          state->include_service_uuids,
-                                          state->include_service_data,
-                                          state->include_manufacturer_data,
-                                          state->include_local_name,
-                                          state->include_tx_power);
+        length = k10_adv_estimated_length(
+            &state->config, state->include_service_uuids, state->include_service_data,
+            state->include_manufacturer_data, state->include_local_name, state->include_tx_power);
     }
 
     if (length > K10_ADV_MAX_LEN && state->include_service_data) {
         k10_log_info("advertising payload too large (%zu); disabling service data", length);
         state->include_service_data = false;
-        length = k10_adv_estimated_length(&state->config,
-                                          state->include_service_uuids,
-                                          state->include_service_data,
-                                          state->include_manufacturer_data,
-                                          state->include_local_name,
-                                          state->include_tx_power);
+        length = k10_adv_estimated_length(
+            &state->config, state->include_service_uuids, state->include_service_data,
+            state->include_manufacturer_data, state->include_local_name, state->include_tx_power);
     }
 
     if (length > K10_ADV_MAX_LEN && state->include_manufacturer_data) {
         k10_log_info("advertising payload too large (%zu); disabling manufacturer data", length);
         state->include_manufacturer_data = false;
-        length = k10_adv_estimated_length(&state->config,
-                                          state->include_service_uuids,
-                                          state->include_service_data,
-                                          state->include_manufacturer_data,
-                                          state->include_local_name,
-                                          state->include_tx_power);
+        length = k10_adv_estimated_length(
+            &state->config, state->include_service_uuids, state->include_service_data,
+            state->include_manufacturer_data, state->include_local_name, state->include_tx_power);
     }
 
     if (length > K10_ADV_MAX_LEN && state->include_tx_power) {
         k10_log_info("advertising payload too large (%zu); disabling TX power", length);
         state->include_tx_power = false;
-        length = k10_adv_estimated_length(&state->config,
-                                          state->include_service_uuids,
-                                          state->include_service_data,
-                                          state->include_manufacturer_data,
-                                          state->include_local_name,
-                                          state->include_tx_power);
+        length = k10_adv_estimated_length(
+            &state->config, state->include_service_uuids, state->include_service_data,
+            state->include_manufacturer_data, state->include_local_name, state->include_tx_power);
     }
 
     if (length > K10_ADV_MAX_LEN && state->include_local_name) {
         k10_log_info("advertising payload too large (%zu); disabling local name", length);
         state->include_local_name = false;
-        length = k10_adv_estimated_length(&state->config,
-                                          state->include_service_uuids,
-                                          state->include_service_data,
-                                          state->include_manufacturer_data,
-                                          state->include_local_name,
-                                          state->include_tx_power);
+        length = k10_adv_estimated_length(
+            &state->config, state->include_service_uuids, state->include_service_data,
+            state->include_manufacturer_data, state->include_local_name, state->include_tx_power);
     }
 
     if (length > K10_ADV_MAX_LEN) {

--- a/src/ble/gatt.c
+++ b/src/ble/gatt.c
@@ -183,8 +183,7 @@ static int k10_gatt_char_get_value(sd_bus *bus, const char *path, const char *in
 
 static int k10_gatt_emit_value(sd_bus *bus, const struct k10_gatt_char_ctx *ctx) {
     if (ctx != NULL && ctx->kind == K10_CHAR_TX && ctx->state != NULL) {
-        k10_gatt_log_value("gatt notify (tx)", ctx->state->tx_value, ctx->state->tx_len,
-                           ctx->state->tx_uuid);
+        k10_gatt_log_value("gatt notify (tx)", ctx->state->tx_value, ctx->state->tx_len, ctx->uuid);
     }
     return sd_bus_emit_properties_changed(bus, ctx->path, K10_GATT_CHAR_IFACE, "Value", NULL);
 }
@@ -203,13 +202,13 @@ static int k10_gatt_char_read_value(sd_bus_message *m, void *userdata, sd_bus_er
     if (ctx->kind == K10_CHAR_TX) {
         value = ctx->state->tx_value;
         length = ctx->state->tx_len;
-        k10_log_info("gatt read (tx) len=%zu uuid=%s", length, ctx->state->tx_uuid);
-        k10_gatt_log_value("gatt read (tx)", value, length, ctx->state->tx_uuid);
+        k10_log_info("gatt read (tx) len=%zu uuid=%s", length, ctx->uuid);
+        k10_gatt_log_value("gatt read (tx)", value, length, ctx->uuid);
     } else {
         value = ctx->state->rx_value;
         length = ctx->state->rx_len;
-        k10_log_info("gatt read (rx) len=%zu uuid=%s", length, ctx->state->rx_uuid);
-        k10_gatt_log_value("gatt read (rx)", value, length, ctx->state->rx_uuid);
+        k10_log_info("gatt read (rx) len=%zu uuid=%s", length, ctx->uuid);
+        k10_gatt_log_value("gatt read (rx)", value, length, ctx->uuid);
     }
 
     r = sd_bus_message_new_method_return(m, &reply);
@@ -271,8 +270,8 @@ static int k10_gatt_char_write_value(sd_bus_message *m, void *userdata, sd_bus_e
 
     memcpy(ctx->state->rx_value, value, length);
     ctx->state->rx_len = length;
-    k10_log_info("gatt write (rx) len=%zu uuid=%s", length, ctx->state->rx_uuid);
-    k10_gatt_log_value("gatt write (rx)", value, length, ctx->state->rx_uuid);
+    k10_log_info("gatt write (rx) len=%zu uuid=%s", length, ctx->uuid);
+    k10_gatt_log_value("gatt write (rx)", value, length, ctx->uuid);
 
     if (ctx->state->tx_notifying) {
         size_t copy_len = length;
@@ -299,7 +298,7 @@ static int k10_gatt_char_start_notify(sd_bus_message *m, void *userdata, sd_bus_
     }
 
     ctx->state->tx_notifying = true;
-    k10_log_info("gatt notify enabled uuid=%s", ctx->state->tx_uuid);
+    k10_log_info("gatt notify enabled uuid=%s", ctx->uuid);
     k10_gatt_emit_value(sd_bus_message_get_bus(m), ctx);
     return sd_bus_reply_method_return(m, "");
 }
@@ -316,7 +315,7 @@ static int k10_gatt_char_stop_notify(sd_bus_message *m, void *userdata, sd_bus_e
     }
 
     ctx->state->tx_notifying = false;
-    k10_log_info("gatt notify disabled uuid=%s", ctx->state->tx_uuid);
+    k10_log_info("gatt notify disabled uuid=%s", ctx->uuid);
     return sd_bus_reply_method_return(m, "");
 }
 

--- a/src/ble/gatt.c
+++ b/src/ble/gatt.c
@@ -179,6 +179,9 @@ static int k10_gatt_char_get_value(sd_bus *bus, const char *path, const char *in
 }
 
 static int k10_gatt_emit_value(sd_bus *bus, const struct k10_gatt_char_ctx *ctx) {
+    if (ctx != NULL && ctx->kind == K10_CHAR_TX && ctx->state != NULL) {
+        k10_gatt_log_value("gatt notify (tx)", ctx->state->tx_value, ctx->state->tx_len);
+    }
     return sd_bus_emit_properties_changed(bus, ctx->path, K10_GATT_CHAR_IFACE, "Value", NULL);
 }
 

--- a/src/ble/gatt.c
+++ b/src/ble/gatt.c
@@ -416,7 +416,7 @@ static void k10_gatt_set_defaults(struct k10_gatt_state *state) {
 
 int k10_gatt_start(sd_bus *bus, struct k10_gatt_state *state, const struct k10_config *config) {
     static const char *rx_flags[] = {"write", "write-without-response"};
-    static const char *tx_flags[] = {"read", "notify"};
+    static const char *tx_flags[] = {"notify"};
     int r = 0;
 
     if (bus == NULL || state == NULL || config == NULL) {
@@ -462,8 +462,7 @@ int k10_gatt_start(sd_bus *bus, struct k10_gatt_state *state, const struct k10_c
     k10_tx_ctx.uuid = K10_GATT_CHAR_TX_UUID;
     k10_tx_ctx.service_path = K10_GATT_SERVICE_PATH;
     k10_tx_ctx.flags[0] = tx_flags[0];
-    k10_tx_ctx.flags[1] = tx_flags[1];
-    k10_tx_ctx.flag_count = 2;
+    k10_tx_ctx.flag_count = 1;
 
     if (state->rx_slot == NULL) {
         r = sd_bus_add_object_vtable(bus, &state->rx_slot, K10_GATT_CHAR_RX_PATH,

--- a/src/ble/gatt.c
+++ b/src/ble/gatt.c
@@ -37,6 +37,8 @@ struct k10_gatt_char_ctx {
 static struct k10_gatt_char_ctx k10_rx_ctx;
 static struct k10_gatt_char_ctx k10_tx_ctx;
 
+static void k10_gatt_log_value(const char *label, const uint8_t *value, size_t length);
+
 static int k10_gatt_service_get_uuid(sd_bus *bus, const char *path, const char *interface,
                                      const char *property, sd_bus_message *reply, void *userdata,
                                      sd_bus_error *ret_error) {

--- a/src/ble/gatt.c
+++ b/src/ble/gatt.c
@@ -1,0 +1,528 @@
+#include "k10_barrel/gatt.h"
+
+#include "k10_barrel/dbus_defs.h"
+#include "k10_barrel/log.h"
+
+#include <errno.h>
+#include <string.h>
+
+#include <systemd/sd-bus.h>
+
+#define K10_BLUEZ_SERVICE "org.bluez"
+#define K10_GATT_MGR_IFACE "org.bluez.GattManager1"
+#define K10_GATT_SERVICE_IFACE "org.bluez.GattService1"
+#define K10_GATT_CHAR_IFACE "org.bluez.GattCharacteristic1"
+
+#define K10_GATT_APP_PATH "/ro/vilt/SwitchbotBleEmulator"
+#define K10_GATT_SERVICE_PATH "/ro/vilt/SwitchbotBleEmulator/service0"
+#define K10_GATT_CHAR_RX_PATH "/ro/vilt/SwitchbotBleEmulator/char_rx"
+#define K10_GATT_CHAR_TX_PATH "/ro/vilt/SwitchbotBleEmulator/char_tx"
+
+#define K10_GATT_SERVICE_UUID "CBA20D00-224D-11E6-9FB8-0002A5D5C51B"
+#define K10_GATT_CHAR_RX_UUID "CBA20002-224D-11E6-9FB8-0002A5D5C51B"
+#define K10_GATT_CHAR_TX_UUID "CBA20003-224D-11E6-9FB8-0002A5D5C51B"
+
+enum k10_gatt_char_kind { K10_CHAR_RX = 0, K10_CHAR_TX = 1 };
+
+struct k10_gatt_char_ctx {
+    struct k10_gatt_state *state;
+    enum k10_gatt_char_kind kind;
+    const char *path;
+    const char *uuid;
+    const char *service_path;
+    const char *flags[4];
+    unsigned int flag_count;
+};
+
+static struct k10_gatt_char_ctx k10_rx_ctx;
+static struct k10_gatt_char_ctx k10_tx_ctx;
+
+static int k10_gatt_service_get_uuid(sd_bus *bus, const char *path, const char *interface,
+                                     const char *property, sd_bus_message *reply, void *userdata,
+                                     sd_bus_error *ret_error) {
+    (void)bus;
+    (void)path;
+    (void)interface;
+    (void)property;
+    (void)userdata;
+    (void)ret_error;
+
+    return sd_bus_message_append(reply, "s", K10_GATT_SERVICE_UUID);
+}
+
+static int k10_gatt_service_get_primary(sd_bus *bus, const char *path, const char *interface,
+                                        const char *property, sd_bus_message *reply, void *userdata,
+                                        sd_bus_error *ret_error) {
+    (void)bus;
+    (void)path;
+    (void)interface;
+    (void)property;
+    (void)userdata;
+    (void)ret_error;
+
+    return sd_bus_message_append(reply, "b", true);
+}
+
+static int k10_gatt_service_get_includes(sd_bus *bus, const char *path, const char *interface,
+                                         const char *property, sd_bus_message *reply,
+                                         void *userdata, sd_bus_error *ret_error) {
+    (void)bus;
+    (void)path;
+    (void)interface;
+    (void)property;
+    (void)userdata;
+    (void)ret_error;
+
+    int r = sd_bus_message_open_container(reply, 'a', "o");
+    if (r < 0) {
+        return r;
+    }
+
+    return sd_bus_message_close_container(reply);
+}
+
+static int k10_gatt_char_get_uuid(sd_bus *bus, const char *path, const char *interface,
+                                  const char *property, sd_bus_message *reply, void *userdata,
+                                  sd_bus_error *ret_error) {
+    struct k10_gatt_char_ctx *ctx = userdata;
+
+    (void)bus;
+    (void)path;
+    (void)interface;
+    (void)property;
+    (void)ret_error;
+
+    return sd_bus_message_append(reply, "s", ctx->uuid);
+}
+
+static int k10_gatt_char_get_service(sd_bus *bus, const char *path, const char *interface,
+                                     const char *property, sd_bus_message *reply, void *userdata,
+                                     sd_bus_error *ret_error) {
+    struct k10_gatt_char_ctx *ctx = userdata;
+
+    (void)bus;
+    (void)path;
+    (void)interface;
+    (void)property;
+    (void)ret_error;
+
+    return sd_bus_message_append(reply, "o", ctx->service_path);
+}
+
+static int k10_gatt_char_get_flags(sd_bus *bus, const char *path, const char *interface,
+                                   const char *property, sd_bus_message *reply, void *userdata,
+                                   sd_bus_error *ret_error) {
+    struct k10_gatt_char_ctx *ctx = userdata;
+    int r = 0;
+
+    (void)bus;
+    (void)path;
+    (void)interface;
+    (void)property;
+    (void)ret_error;
+
+    r = sd_bus_message_open_container(reply, 'a', "s");
+    if (r < 0) {
+        return r;
+    }
+
+    for (unsigned int i = 0; i < ctx->flag_count; i++) {
+        r = sd_bus_message_append(reply, "s", ctx->flags[i]);
+        if (r < 0) {
+            return r;
+        }
+    }
+
+    return sd_bus_message_close_container(reply);
+}
+
+static int k10_gatt_char_get_notifying(sd_bus *bus, const char *path, const char *interface,
+                                       const char *property, sd_bus_message *reply, void *userdata,
+                                       sd_bus_error *ret_error) {
+    struct k10_gatt_char_ctx *ctx = userdata;
+
+    (void)bus;
+    (void)path;
+    (void)interface;
+    (void)property;
+    (void)ret_error;
+
+    if (ctx->kind != K10_CHAR_TX) {
+        return sd_bus_message_append(reply, "b", false);
+    }
+
+    return sd_bus_message_append(reply, "b", ctx->state->tx_notifying);
+}
+
+static int k10_gatt_char_get_value(sd_bus *bus, const char *path, const char *interface,
+                                   const char *property, sd_bus_message *reply, void *userdata,
+                                   sd_bus_error *ret_error) {
+    struct k10_gatt_char_ctx *ctx = userdata;
+    const uint8_t *value = NULL;
+    size_t length = 0;
+
+    (void)bus;
+    (void)path;
+    (void)interface;
+    (void)property;
+    (void)ret_error;
+
+    if (ctx->kind == K10_CHAR_TX) {
+        value = ctx->state->tx_value;
+        length = ctx->state->tx_len;
+    } else {
+        value = ctx->state->rx_value;
+        length = ctx->state->rx_len;
+    }
+
+    return sd_bus_message_append_array(reply, 'y', value, length);
+}
+
+static int k10_gatt_emit_value(sd_bus *bus, const struct k10_gatt_char_ctx *ctx) {
+    return sd_bus_emit_properties_changed(bus, ctx->path, K10_GATT_CHAR_IFACE, "Value", NULL);
+}
+
+static int k10_gatt_char_read_value(sd_bus_message *m, void *userdata, sd_bus_error *ret_error) {
+    struct k10_gatt_char_ctx *ctx = userdata;
+    sd_bus_message *reply = NULL;
+    const uint8_t *value = NULL;
+    size_t length = 0;
+    int r = 0;
+
+    (void)ret_error;
+
+    sd_bus_message_skip(m, "a{sv}");
+
+    if (ctx->kind == K10_CHAR_TX) {
+        value = ctx->state->tx_value;
+        length = ctx->state->tx_len;
+    } else {
+        value = ctx->state->rx_value;
+        length = ctx->state->rx_len;
+    }
+
+    r = sd_bus_message_new_method_return(m, &reply);
+    if (r < 0) {
+        return r;
+    }
+
+    r = sd_bus_message_append_array(reply, 'y', value, length);
+    if (r < 0) {
+        sd_bus_message_unref(reply);
+        return r;
+    }
+
+    r = sd_bus_send(sd_bus_message_get_bus(m), reply, NULL);
+    sd_bus_message_unref(reply);
+    return r;
+}
+
+static void k10_gatt_log_value(const char *label, const uint8_t *value, size_t length) {
+    char buffer[1024];
+    size_t offset = 0;
+
+    for (size_t i = 0; i < length && offset + 3 < sizeof(buffer); i++) {
+        offset += (size_t)snprintf(buffer + offset, sizeof(buffer) - offset, "%02X",
+                                   (unsigned int)value[i]);
+    }
+
+    buffer[offset] = '\0';
+    k10_log_info("%s len=%zu data=%s", label, length, buffer);
+}
+
+static int k10_gatt_char_write_value(sd_bus_message *m, void *userdata, sd_bus_error *ret_error) {
+    struct k10_gatt_char_ctx *ctx = userdata;
+    const uint8_t *value = NULL;
+    size_t length = 0;
+    int r = 0;
+
+    if (ctx->kind != K10_CHAR_RX) {
+        sd_bus_error_set(ret_error, "org.bluez.Error.NotSupported",
+                         "Write is only supported on RX characteristic");
+        return -1;
+    }
+
+    r = sd_bus_message_read_array(m, 'y', (const void **)&value, &length);
+    if (r < 0) {
+        return r;
+    }
+    sd_bus_message_skip(m, "a{sv}");
+
+    if (length > sizeof(ctx->state->rx_value)) {
+        length = sizeof(ctx->state->rx_value);
+    }
+
+    memcpy(ctx->state->rx_value, value, length);
+    ctx->state->rx_len = length;
+    k10_gatt_log_value("gatt write (rx)", value, length);
+
+    if (ctx->state->tx_notifying) {
+        size_t copy_len = length;
+        if (copy_len > sizeof(ctx->state->tx_value)) {
+            copy_len = sizeof(ctx->state->tx_value);
+        }
+        memcpy(ctx->state->tx_value, value, copy_len);
+        ctx->state->tx_len = copy_len;
+        k10_gatt_emit_value(sd_bus_message_get_bus(m), &k10_tx_ctx);
+    }
+
+    return sd_bus_reply_method_return(m, "");
+}
+
+static int k10_gatt_char_start_notify(sd_bus_message *m, void *userdata, sd_bus_error *ret_error) {
+    struct k10_gatt_char_ctx *ctx = userdata;
+
+    (void)ret_error;
+
+    if (ctx->kind != K10_CHAR_TX) {
+        sd_bus_error_set(ret_error, "org.bluez.Error.NotSupported",
+                         "Notify is only supported on TX characteristic");
+        return -1;
+    }
+
+    ctx->state->tx_notifying = true;
+    k10_log_info("gatt notify enabled");
+    k10_gatt_emit_value(sd_bus_message_get_bus(m), ctx);
+    return sd_bus_reply_method_return(m, "");
+}
+
+static int k10_gatt_char_stop_notify(sd_bus_message *m, void *userdata, sd_bus_error *ret_error) {
+    struct k10_gatt_char_ctx *ctx = userdata;
+
+    (void)ret_error;
+
+    if (ctx->kind != K10_CHAR_TX) {
+        sd_bus_error_set(ret_error, "org.bluez.Error.NotSupported",
+                         "Notify is only supported on TX characteristic");
+        return -1;
+    }
+
+    ctx->state->tx_notifying = false;
+    k10_log_info("gatt notify disabled");
+    return sd_bus_reply_method_return(m, "");
+}
+
+static const sd_bus_vtable k10_gatt_service_vtable[] = {
+    SD_BUS_VTABLE_START(0),
+    SD_BUS_PROPERTY("UUID", "s", k10_gatt_service_get_uuid, 0, SD_BUS_VTABLE_PROPERTY_CONST),
+    SD_BUS_PROPERTY("Primary", "b", k10_gatt_service_get_primary, 0, SD_BUS_VTABLE_PROPERTY_CONST),
+    SD_BUS_PROPERTY("Includes", "ao", k10_gatt_service_get_includes, 0,
+                    SD_BUS_VTABLE_PROPERTY_CONST),
+    SD_BUS_VTABLE_END};
+
+static const sd_bus_vtable k10_gatt_char_vtable[] = {
+    SD_BUS_VTABLE_START(0),
+    SD_BUS_METHOD("ReadValue", "a{sv}", "ay", k10_gatt_char_read_value, SD_BUS_VTABLE_UNPRIVILEGED),
+    SD_BUS_METHOD("WriteValue", "aya{sv}", "", k10_gatt_char_write_value,
+                  SD_BUS_VTABLE_UNPRIVILEGED),
+    SD_BUS_METHOD("StartNotify", "", "", k10_gatt_char_start_notify, SD_BUS_VTABLE_UNPRIVILEGED),
+    SD_BUS_METHOD("StopNotify", "", "", k10_gatt_char_stop_notify, SD_BUS_VTABLE_UNPRIVILEGED),
+    SD_BUS_PROPERTY("UUID", "s", k10_gatt_char_get_uuid, 0, SD_BUS_VTABLE_PROPERTY_CONST),
+    SD_BUS_PROPERTY("Service", "o", k10_gatt_char_get_service, 0, SD_BUS_VTABLE_PROPERTY_CONST),
+    SD_BUS_PROPERTY("Flags", "as", k10_gatt_char_get_flags, 0, SD_BUS_VTABLE_PROPERTY_CONST),
+    SD_BUS_PROPERTY("Notifying", "b", k10_gatt_char_get_notifying, 0,
+                    SD_BUS_VTABLE_PROPERTY_EMITS_CHANGE),
+    SD_BUS_PROPERTY("Value", "ay", k10_gatt_char_get_value, 0, SD_BUS_VTABLE_PROPERTY_EMITS_CHANGE),
+    SD_BUS_VTABLE_END};
+
+static int k10_gatt_register_complete(sd_bus_message *m, void *userdata, sd_bus_error *ret_error) {
+    struct k10_gatt_state *state = userdata;
+
+    if (ret_error != NULL && sd_bus_error_is_set(ret_error)) {
+        k10_log_error("gatt register failed: %s",
+                      ret_error->message ? ret_error->message : ret_error->name);
+        state->registered = false;
+    } else if (sd_bus_message_is_method_error(m, NULL)) {
+        const sd_bus_error *error = sd_bus_message_get_error(m);
+        k10_log_error("gatt register failed: %s",
+                      error && error->message ? error->message : "unknown error");
+        state->registered = false;
+    } else {
+        state->registered = true;
+        k10_log_info("gatt registered on %s", state->config.adapter);
+    }
+
+    state->pending = false;
+    sd_bus_slot_unref(state->pending_slot);
+    state->pending_slot = NULL;
+    return 1;
+}
+
+static int k10_gatt_register_async(sd_bus *bus, struct k10_gatt_state *state, const char *adapter) {
+    sd_bus_message *message = NULL;
+    char adapter_path[128];
+    int r = 0;
+
+    snprintf(adapter_path, sizeof(adapter_path), "/org/bluez/%s", adapter);
+
+    r = sd_bus_message_new_method_call(bus, &message, K10_BLUEZ_SERVICE, adapter_path,
+                                       K10_GATT_MGR_IFACE, "RegisterApplication");
+    if (r < 0) {
+        return r;
+    }
+
+    r = sd_bus_message_append(message, "o", state->app_path);
+    if (r < 0) {
+        goto finish;
+    }
+
+    r = sd_bus_message_open_container(message, 'a', "{sv}");
+    if (r < 0) {
+        goto finish;
+    }
+
+    r = sd_bus_message_close_container(message);
+    if (r < 0) {
+        goto finish;
+    }
+
+    r = sd_bus_call_async(bus, &state->pending_slot, message, k10_gatt_register_complete, state, 0);
+
+finish:
+    sd_bus_message_unref(message);
+    return r;
+}
+
+static int k10_gatt_unregister(sd_bus *bus, const struct k10_gatt_state *state,
+                               const char *adapter) {
+    sd_bus_error error = SD_BUS_ERROR_NULL;
+    sd_bus_message *reply = NULL;
+    char adapter_path[128];
+    int r = 0;
+
+    snprintf(adapter_path, sizeof(adapter_path), "/org/bluez/%s", adapter);
+
+    r = sd_bus_call_method(bus, K10_BLUEZ_SERVICE, adapter_path, K10_GATT_MGR_IFACE,
+                           "UnregisterApplication", &error, &reply, "o", state->app_path);
+    if (r < 0) {
+        k10_log_error("gatt unregister failed: %s", error.message ? error.message : strerror(-r));
+    }
+
+    sd_bus_error_free(&error);
+    sd_bus_message_unref(reply);
+    return r;
+}
+
+static void k10_gatt_set_defaults(struct k10_gatt_state *state) {
+    if (state->app_path[0] == '\0') {
+        strncpy(state->app_path, K10_GATT_APP_PATH, sizeof(state->app_path) - 1);
+    }
+}
+
+int k10_gatt_start(sd_bus *bus, struct k10_gatt_state *state, const struct k10_config *config) {
+    static const char *rx_flags[] = {"write", "write-without-response"};
+    static const char *tx_flags[] = {"read", "notify"};
+    int r = 0;
+
+    if (bus == NULL || state == NULL || config == NULL) {
+        return -EINVAL;
+    }
+
+    if (state->registered || state->pending) {
+        return 0;
+    }
+
+    k10_gatt_set_defaults(state);
+    state->config = *config;
+
+    if (state->object_manager_slot == NULL) {
+        r = sd_bus_add_object_manager(bus, &state->object_manager_slot, state->app_path);
+        if (r < 0) {
+            k10_log_error("gatt object manager failed: %s", strerror(-r));
+            return r;
+        }
+    }
+
+    if (state->service_slot == NULL) {
+        r = sd_bus_add_object_vtable(bus, &state->service_slot, K10_GATT_SERVICE_PATH,
+                                     K10_GATT_SERVICE_IFACE, k10_gatt_service_vtable, state);
+        if (r < 0) {
+            k10_log_error("gatt service vtable failed: %s", strerror(-r));
+            return r;
+        }
+    }
+
+    k10_rx_ctx.state = state;
+    k10_rx_ctx.kind = K10_CHAR_RX;
+    k10_rx_ctx.path = K10_GATT_CHAR_RX_PATH;
+    k10_rx_ctx.uuid = K10_GATT_CHAR_RX_UUID;
+    k10_rx_ctx.service_path = K10_GATT_SERVICE_PATH;
+    k10_rx_ctx.flags[0] = rx_flags[0];
+    k10_rx_ctx.flags[1] = rx_flags[1];
+    k10_rx_ctx.flag_count = 2;
+
+    k10_tx_ctx.state = state;
+    k10_tx_ctx.kind = K10_CHAR_TX;
+    k10_tx_ctx.path = K10_GATT_CHAR_TX_PATH;
+    k10_tx_ctx.uuid = K10_GATT_CHAR_TX_UUID;
+    k10_tx_ctx.service_path = K10_GATT_SERVICE_PATH;
+    k10_tx_ctx.flags[0] = tx_flags[0];
+    k10_tx_ctx.flags[1] = tx_flags[1];
+    k10_tx_ctx.flag_count = 2;
+
+    if (state->rx_slot == NULL) {
+        r = sd_bus_add_object_vtable(bus, &state->rx_slot, K10_GATT_CHAR_RX_PATH,
+                                     K10_GATT_CHAR_IFACE, k10_gatt_char_vtable, &k10_rx_ctx);
+        if (r < 0) {
+            k10_log_error("gatt rx vtable failed: %s", strerror(-r));
+            return r;
+        }
+    }
+
+    if (state->tx_slot == NULL) {
+        r = sd_bus_add_object_vtable(bus, &state->tx_slot, K10_GATT_CHAR_TX_PATH,
+                                     K10_GATT_CHAR_IFACE, k10_gatt_char_vtable, &k10_tx_ctx);
+        if (r < 0) {
+            k10_log_error("gatt tx vtable failed: %s", strerror(-r));
+            return r;
+        }
+    }
+
+    r = k10_gatt_register_async(bus, state, config->adapter);
+    if (r < 0) {
+        k10_log_error("gatt register request failed: %s", strerror(-r));
+        return r;
+    }
+
+    state->pending = true;
+    state->registered = false;
+    k10_log_info("gatt register requested on %s", config->adapter);
+    return 0;
+}
+
+int k10_gatt_stop(sd_bus *bus, struct k10_gatt_state *state) {
+    int r = 0;
+
+    if (bus == NULL || state == NULL) {
+        return -EINVAL;
+    }
+
+    if (!state->registered && !state->pending) {
+        return 0;
+    }
+
+    if (state->pending_slot != NULL) {
+        sd_bus_slot_unref(state->pending_slot);
+        state->pending_slot = NULL;
+        state->pending = false;
+    }
+
+    if (state->registered) {
+        r = k10_gatt_unregister(bus, state, state->config.adapter);
+    }
+
+    sd_bus_slot_unref(state->tx_slot);
+    state->tx_slot = NULL;
+    sd_bus_slot_unref(state->rx_slot);
+    state->rx_slot = NULL;
+    sd_bus_slot_unref(state->service_slot);
+    state->service_slot = NULL;
+    sd_bus_slot_unref(state->object_manager_slot);
+    state->object_manager_slot = NULL;
+    state->registered = false;
+    state->pending = false;
+    state->tx_notifying = false;
+    state->rx_len = 0;
+    state->tx_len = 0;
+    return r;
+}

--- a/src/config/config.c
+++ b/src/config/config.c
@@ -21,6 +21,7 @@ static void k10_config_set_defaults(struct k10_config *config) {
     strncpy(config->sweeper_fd3d_service_data_hex, "7d00",
             sizeof(config->sweeper_fd3d_service_data_hex) - 1);
     config->include_tx_power = true;
+    config->use_random_address = true;
     config->fw_major = 1;
     config->fw_minor = 0;
 }
@@ -261,6 +262,10 @@ static int k10_apply_config_line(char *line, struct k10_config *config) {
         return k10_parse_bool(value, &config->include_tx_power);
     }
 
+    if (strcmp(key, "use_random_address") == 0) {
+        return k10_parse_bool(value, &config->use_random_address);
+    }
+
     if (strcmp(key, "fw_major") == 0) {
         return k10_parse_uint(value, &config->fw_major);
     }
@@ -381,6 +386,7 @@ int k10_config_save(const char *path, const struct k10_config *config) {
             config->sweeper_fd3d_service_data_hex);
     fprintf(file, "barrel_fd3d_service_data_hex = \"%s\"\n", config->barrel_fd3d_service_data_hex);
     fprintf(file, "include_tx_power = %s\n", config->include_tx_power ? "true" : "false");
+    fprintf(file, "use_random_address = %s\n", config->use_random_address ? "true" : "false");
     fprintf(file, "fw_major = %u\n", config->fw_major);
     fprintf(file, "fw_minor = %u\n", config->fw_minor);
 

--- a/src/config/config.c
+++ b/src/config/config.c
@@ -15,8 +15,10 @@ static void k10_config_set_defaults(struct k10_config *config) {
     strncpy(config->adapter, "hci0", sizeof(config->adapter) - 1);
     strncpy(config->local_name, "WoS1MB", sizeof(config->local_name) - 1);
     config->company_id = 0x0969;
-    strncpy(config->sweeper_mfg_suffix, "022064", sizeof(config->sweeper_mfg_suffix) - 1);
-    strncpy(config->barrel_mfg_suffix, "0316230200", sizeof(config->barrel_mfg_suffix) - 1);
+    strncpy(config->sweeper_mfg_suffix, "2064", sizeof(config->sweeper_mfg_suffix) - 1);
+    strncpy(config->barrel_mfg_suffix, "16230200", sizeof(config->barrel_mfg_suffix) - 1);
+    strncpy(config->sweeper_fd3d_service_data_hex, "7d00",
+            sizeof(config->sweeper_fd3d_service_data_hex) - 1);
     config->include_tx_power = true;
     config->fw_major = 1;
     config->fw_minor = 0;
@@ -239,6 +241,16 @@ static int k10_apply_config_line(char *line, struct k10_config *config) {
                                 sizeof(config->fd3d_service_data_hex));
     }
 
+    if (strcmp(key, "sweeper_fd3d_service_data_hex") == 0) {
+        return k10_parse_string(value, config->sweeper_fd3d_service_data_hex,
+                                sizeof(config->sweeper_fd3d_service_data_hex));
+    }
+
+    if (strcmp(key, "barrel_fd3d_service_data_hex") == 0) {
+        return k10_parse_string(value, config->barrel_fd3d_service_data_hex,
+                                sizeof(config->barrel_fd3d_service_data_hex));
+    }
+
     if (strcmp(key, "include_tx_power") == 0) {
         return k10_parse_bool(value, &config->include_tx_power);
     }
@@ -358,6 +370,9 @@ int k10_config_save(const char *path, const struct k10_config *config) {
     fprintf(file, "]\n");
 
     fprintf(file, "fd3d_service_data_hex = \"%s\"\n", config->fd3d_service_data_hex);
+    fprintf(file, "sweeper_fd3d_service_data_hex = \"%s\"\n",
+            config->sweeper_fd3d_service_data_hex);
+    fprintf(file, "barrel_fd3d_service_data_hex = \"%s\"\n", config->barrel_fd3d_service_data_hex);
     fprintf(file, "include_tx_power = %s\n", config->include_tx_power ? "true" : "false");
     fprintf(file, "fw_major = %u\n", config->fw_major);
     fprintf(file, "fw_minor = %u\n", config->fw_minor);

--- a/src/config/config.c
+++ b/src/config/config.c
@@ -14,6 +14,7 @@ static void k10_config_set_defaults(struct k10_config *config) {
     memset(config, 0, sizeof(*config));
     strncpy(config->adapter, "hci0", sizeof(config->adapter) - 1);
     strncpy(config->local_name, "WoS1MB", sizeof(config->local_name) - 1);
+    strncpy(config->advertising_backend, "bluez", sizeof(config->advertising_backend) - 1);
     config->company_id = 0x0969;
     strncpy(config->sweeper_mfg_suffix, "2064", sizeof(config->sweeper_mfg_suffix) - 1);
     strncpy(config->barrel_mfg_suffix, "16230200", sizeof(config->barrel_mfg_suffix) - 1);
@@ -213,6 +214,11 @@ static int k10_apply_config_line(char *line, struct k10_config *config) {
         return k10_parse_string(value, config->local_name, sizeof(config->local_name));
     }
 
+    if (strcmp(key, "advertising_backend") == 0) {
+        return k10_parse_string(value, config->advertising_backend,
+                                sizeof(config->advertising_backend));
+    }
+
     if (strcmp(key, "company_id") == 0) {
         return k10_parse_uint(value, &config->company_id);
     }
@@ -355,6 +361,7 @@ int k10_config_save(const char *path, const struct k10_config *config) {
 
     fprintf(file, "adapter = \"%s\"\n", config->adapter);
     fprintf(file, "local_name = \"%s\"\n", config->local_name);
+    fprintf(file, "advertising_backend = \"%s\"\n", config->advertising_backend);
     fprintf(file, "company_id = 0x%04X\n", config->company_id);
     fprintf(file, "manufacturer_mac_label = \"%s\"\n", config->manufacturer_mac_label);
     fprintf(file, "sweeper_mfg_suffix = \"%s\"\n", config->sweeper_mfg_suffix);

--- a/src/config/config.c
+++ b/src/config/config.c
@@ -15,6 +15,8 @@ static void k10_config_set_defaults(struct k10_config *config) {
     strncpy(config->adapter, "hci0", sizeof(config->adapter) - 1);
     strncpy(config->local_name, "WoS1MB", sizeof(config->local_name) - 1);
     config->company_id = 0x0969;
+    strncpy(config->sweeper_mfg_suffix, "022064", sizeof(config->sweeper_mfg_suffix) - 1);
+    strncpy(config->barrel_mfg_suffix, "0316230200", sizeof(config->barrel_mfg_suffix) - 1);
     config->include_tx_power = true;
     config->fw_major = 1;
     config->fw_minor = 0;
@@ -218,6 +220,16 @@ static int k10_apply_config_line(char *line, struct k10_config *config) {
                                 sizeof(config->manufacturer_mac_label));
     }
 
+    if (strcmp(key, "sweeper_mfg_suffix") == 0) {
+        return k10_parse_string(value, config->sweeper_mfg_suffix,
+                                sizeof(config->sweeper_mfg_suffix));
+    }
+
+    if (strcmp(key, "barrel_mfg_suffix") == 0) {
+        return k10_parse_string(value, config->barrel_mfg_suffix,
+                                sizeof(config->barrel_mfg_suffix));
+    }
+
     if (strcmp(key, "service_uuids") == 0) {
         return k10_parse_service_uuids(value, config);
     }
@@ -333,6 +345,8 @@ int k10_config_save(const char *path, const struct k10_config *config) {
     fprintf(file, "local_name = \"%s\"\n", config->local_name);
     fprintf(file, "company_id = 0x%04X\n", config->company_id);
     fprintf(file, "manufacturer_mac_label = \"%s\"\n", config->manufacturer_mac_label);
+    fprintf(file, "sweeper_mfg_suffix = \"%s\"\n", config->sweeper_mfg_suffix);
+    fprintf(file, "barrel_mfg_suffix = \"%s\"\n", config->barrel_mfg_suffix);
 
     fprintf(file, "service_uuids = [");
     for (unsigned int i = 0; i < config->service_uuid_count; i++) {

--- a/src/dbus/dbus.c
+++ b/src/dbus/dbus.c
@@ -298,6 +298,11 @@ static int k10_dbus_append_config(sd_bus_message *msg, const struct k10_config *
         return r;
     }
 
+    r = k10_dbus_append_kv_string(msg, "advertising_backend", config->advertising_backend);
+    if (r < 0) {
+        return r;
+    }
+
     r = k10_dbus_append_kv_uint(msg, "company_id", config->company_id);
     if (r < 0) {
         return r;
@@ -673,6 +678,10 @@ static int k10_method_set_config(sd_bus_message *m, void *userdata, sd_bus_error
         } else if (strcmp(key, "local_name") == 0) {
             r = k10_dbus_apply_string(m, updated_config.local_name,
                                       sizeof(updated_config.local_name));
+            entry_updated = (r >= 0);
+        } else if (strcmp(key, "advertising_backend") == 0) {
+            r = k10_dbus_apply_string(m, updated_config.advertising_backend,
+                                      sizeof(updated_config.advertising_backend));
             entry_updated = (r >= 0);
         } else if (strcmp(key, "company_id") == 0) {
             r = k10_dbus_apply_uint(m, &updated_config.company_id);

--- a/src/dbus/dbus.c
+++ b/src/dbus/dbus.c
@@ -4,6 +4,7 @@
 #include "k10_barrel/gatt.h"
 #include "k10_barrel/log.h"
 
+#include <ctype.h>
 #include <signal.h>
 #include <stdbool.h>
 #include <stdint.h>
@@ -25,6 +26,9 @@ struct k10_control_binding {
 
 static volatile sig_atomic_t k10_should_exit = 0;
 
+static int k10_get_adapter_address(sd_bus *bus, const char *adapter, char *out, size_t out_size);
+static void k10_format_mfg_label(char *out, size_t out_size, const char *mac, const char *suffix);
+
 static const char *k10_mode_to_string(enum k10_emulator_mode mode) {
     switch (mode) {
     case K10_MODE_SWEEPER:
@@ -43,7 +47,7 @@ static void k10_apply_mode_name(struct k10_config *config, enum k10_emulator_mod
 
     switch (mode) {
     case K10_MODE_SWEEPER:
-        strncpy(config->local_name, "WoS1MINI", sizeof(config->local_name) - 1);
+        strncpy(config->local_name, "WoS1MI", sizeof(config->local_name) - 1);
         config->local_name[sizeof(config->local_name) - 1] = '\0';
         break;
     case K10_MODE_BARREL:

--- a/src/dbus/dbus.c
+++ b/src/dbus/dbus.c
@@ -5,6 +5,7 @@
 #include "k10_barrel/log.h"
 
 #include <ctype.h>
+#include <errno.h>
 #include <signal.h>
 #include <stdbool.h>
 #include <stdint.h>

--- a/src/dbus/dbus.c
+++ b/src/dbus/dbus.c
@@ -69,6 +69,10 @@ static void k10_apply_mode_mfg(struct k10_config *config, sd_bus *bus,
         return;
     }
 
+    if (config->manufacturer_mac_label[0] != '\0') {
+        return;
+    }
+
     if (k10_get_adapter_address(bus, config->adapter, address, sizeof(address)) != 0) {
         return;
     }

--- a/src/dbus/dbus.c
+++ b/src/dbus/dbus.c
@@ -355,6 +355,11 @@ static int k10_dbus_append_config(sd_bus_message *msg, const struct k10_config *
         return r;
     }
 
+    r = k10_dbus_append_kv_bool(msg, "use_random_address", config->use_random_address);
+    if (r < 0) {
+        return r;
+    }
+
     r = k10_dbus_append_kv_uint(msg, "fw_major", config->fw_major);
     if (r < 0) {
         return r;
@@ -719,6 +724,9 @@ static int k10_method_set_config(sd_bus_message *m, void *userdata, sd_bus_error
             entry_updated = (r >= 0);
         } else if (strcmp(key, "include_tx_power") == 0) {
             r = k10_dbus_apply_bool(m, &updated_config.include_tx_power);
+            entry_updated = (r >= 0);
+        } else if (strcmp(key, "use_random_address") == 0) {
+            r = k10_dbus_apply_bool(m, &updated_config.use_random_address);
             entry_updated = (r >= 0);
         } else if (strcmp(key, "fw_major") == 0) {
             r = k10_dbus_apply_uint(m, &updated_config.fw_major);


### PR DESCRIPTION
## Summary
- register BlueZ LE advertisement based on config (UUIDs, manufacturer data, FD3D service data, tx power)
- wire Start/Stop/Reload to advertising state and expose advertising status
- add advertising module and document it

## Testing
- not run (local clang-format/systemd tools unavailable on macOS)
- Closes #17